### PR TITLE
WIP: explicit specification of lhs in tensor expressions

### DIFF
--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -50,35 +50,42 @@ class Primitives:
         tensor: _ASNode,
         indices: Union[AbstractIndex, Iterable[AbstractIndex]]
     ):
-        '''indexed notation for a single tensor'''
+        '''indexed notation for a single tensor: tensor[indices...]'''
 
     @primitive(precedence=2)
     def call(f: str, x: _ASNode):
-        '''nonlinear function call'''
+        '''nonlinear function call: f(x)'''
 
     @primitive(precedence=3)
     def pow(base: _ASNode, exponent: _ASNode):
-        '''raise to power'''
+        '''raise to power: base**exponent'''
 
     @primitive(precedence=4)
     def neg(x: _ASNode):
-        '''elementwise negation'''
+        '''elementwise negation: -x'''
 
     @primitive(precedence=5)
     def mul(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise multiplication, Hadamard product'''
+        '''multiplication: lhs * rhs'''
 
     @primitive(precedence=5)
     def div(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise division'''
+        '''division: lhs / rhs'''
 
     @primitive(precedence=6)
     def add(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise addition'''
+        '''addition: lhs + rhs'''
 
     @primitive(precedence=6)
     def sub(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise subtraction'''
+        '''subtraction: lhs - rhs'''
+
+    @primitive(precedence=7)
+    def let(
+        dst: Union[AbstractIndex, Iterable[AbstractIndex]],
+        src: _ASNode
+    ):
+        '''explicit specify output indices'''
 
     @classmethod
     def as_primitive(cls, value):

--- a/funfact/lang/_tensor.py
+++ b/funfact/lang/_tensor.py
@@ -17,16 +17,20 @@ class Identifier(ABC):
     @symbol.setter
     def symbol(self, string: str):
         m = re.fullmatch(r'([a-zA-Z]+)(?:_(\d+))?', string)
-        if m is None:
-            raise RuntimeError(
-                f'{repr(string)} is not a valid symbol.\n'
-                'A symbol must be alphabetic and optionally followed by an '
-                'underscore and a numeric subscript. '
-                'Examples: i, j, k_0, lhs, etc.'
-            )
-        self._letter, self._number = m.groups()
-        if self._letter == 'Anonymous':
-            self._letter = r'\varphi'
+        try:
+            self._letter, self._number = m.groups()
+        except AttributeError:
+            m = re.fullmatch(r'__(\d+)', string)
+            try:
+                self._letter = r'\lambda'
+                self._number, = m.groups()
+            except AttributeError:
+                raise RuntimeError(
+                    f'{repr(string)} is not a valid symbol.\n'
+                    'A symbol must be alphabetic and optionally followed by '
+                    'an underscore and a numeric subscript. '
+                    'Examples: i, j, k_0, lhs, etc.'
+                )
 
     @abstractmethod
     def _repr_tex_(self):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -84,7 +84,6 @@ class TsrEx(_AST):
         return self._as_tree(P.pow(self._as_node(base)), self.root)
 
     def __getitem__(self, indices):
-        assert isinstance(self.root, P.tensor)
         tsrnode = self.root
         if isinstance(indices, typing.Iterable):
             assert len(indices) == tsrnode.value.ndim,\
@@ -96,6 +95,14 @@ class TsrEx(_AST):
             assert 1 == tsrnode.value.ndim,\
                 f"Indices {indices} does not match the rank of tensor {self}."
             return TsrEx(P.index_notation(tsrnode, (indices.root,)))
+
+    def __eq__(self, rhs):
+        if not isinstance(self.root, P.index_notation):
+            raise SyntaxError(
+                f'Only an index notation can act as the left-hand side of '
+                f'assignment. Got {self.root}.'
+            )
+        return TsrEx(P.let(self.root.indices, rhs.root))
 
 
 def index(symbol):
@@ -136,7 +143,8 @@ def tensor(*spec, initializer=None):
     elif isinstance(spec[0], str):
         symbol, *size = spec
     else:
-        symbol = f'Anonymous_{AbstractTensor.n_nameless}'
+        # internal format for anonymous symbols
+        symbol = f'__{AbstractTensor.n_nameless}'
         AbstractTensor.n_nameless += 1
         size = spec
 

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -53,3 +53,7 @@ class ASCIIRenderer(TranscribeInterpreter):
     @as_payload
     def sub(self, lhs, rhs, **kwargs):
         return '-'
+
+    @as_payload
+    def let(self, dst, src, **kwargs):
+        return '=='

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -90,3 +90,8 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
         map = IndexMap()
         return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
                f'->{map(live_indices)}'
+
+    @as_payload
+    def let(self, dst, src: Numeric, live_indices, **kwargs):
+        map = IndexMap()
+        return f'{map(src.live_indices)}->{map(live_indices)}'

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -45,3 +45,7 @@ class Evaluator(ROOFInterpreter):
 
     def sub(self, lhs, rhs, einspec, **kwargs):
         return self._binary_operator(np.subtract, lhs, rhs, einspec)
+
+    def let(self, dst, src, einspec, **kwargs):
+        src_spec, dst_spec = einspec.split('->')
+        return np.transpose(src, [src_spec.index(i) for i in dst_spec])

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -70,3 +70,7 @@ class IndexPropagator(TranscribeInterpreter):
     @as_payload
     def sub(self, lhs: Numeric, rhs: Numeric, **kwargs):
         return ordered_symmetric_difference(lhs.live_indices, rhs.live_indices)
+
+    @as_payload
+    def let(self, dst: Iterable[P.index], src: Numeric, **kwargs):
+        return list(it.chain.from_iterable([i.live_indices for i in dst]))

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -71,3 +71,7 @@ class LeafInitializer(TranscribeInterpreter):
     @as_payload
     def sub(self, lhs, rhs, **kwargs):
         return None
+
+    @as_payload
+    def let(self, dst, src, **kwargs):
+        return None

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -47,3 +47,6 @@ class LatexRenderer(ROOFInterpreter):
 
     def sub(self, lhs, rhs, **kwargs):
         return fr'{lhs} - {rhs}'
+
+    def let(self, dst, src, **kwargs):
+        return fr'''\boxed{{\phantom{{x}}}}_{{{''.join(dst)}}} = {src}'''

--- a/funfact/lang/interpreter/_syntax_validation.py
+++ b/funfact/lang/interpreter/_syntax_validation.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from funfact.lang._ast import _ASNode, _AST, Primitives as P
+from ._base import _deep_apply
+
+
+class SyntaxValidator:
+    '''A ROOF (Read-Only On-the-Fly) interpreter traverses an AST for one pass
+    and produces the final outcome without altering the AST. Intermediates are
+    passed as return values between the traversing levels. Its primitive rules
+    may still accept a 'payload' argument, which could be potentially produced
+    by another transcribe interpreter.'''
+
+    def scalar(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def tensor(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def index(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def index_notation(self, node: _ASNode, parent: _ASNode):
+        if not isinstance(node.tensor, P.tensor):
+            raise SyntaxError(
+                f'Index notation only applies to a tensor object, '
+                f'got {node.tensor} instead.'
+            )
+
+    def call(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def pow(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def neg(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def mul(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def div(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def add(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def sub(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def let(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def __call__(self, node: _ASNode, parent: _ASNode = None):
+        for name, value in node.fields_fixed.items():
+            _deep_apply(self, value, node)
+        return getattr(self, node.name)(node, parent)
+
+    def __ror__(self, tsrex: _AST):
+        self(tsrex.root)


### PR DESCRIPTION
Added the `==` operator for the explicit specification of output tensor indices.

For example,
```
A = ff.tensor(2, 3)
B = ff.tensor(3, 4)
C = ff.tensor(2, 4)
i, j, k = ff.indices('i, j, k')
tsrex = C[k, i] == A[i, j] * B[j, k]
```
give rise to the following tensor expression
```
 ==
 ├── k
 ├── i
 ╰── *
     ├── A[i,j]
     │   ├── A
     │   ├── i
     │   ╰── j
     ╰── B[j,k]
         ├── B
         ├── j
         ╰── k
```
which in addition to carrying out the inner product, also transposes the final result.

Note that this PR alone does not fully implement the `einsum` semantics, where an index in the output string also suppresses the reduction over its associated dimensions. This will be address by #17 through the introduction of an **index modifier** syntax.

Closes #6 upon completion.