### PR TITLE
Added the `>>` syntax for specifying output indices.

### DIFF
--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -3,7 +3,7 @@
 from dataclasses import make_dataclass
 import inspect
 from numbers import Real
-from typing import Iterable, Union
+from typing import Tuple
 from ._tensor import AbstractIndex, AbstractTensor
 
 
@@ -38,27 +38,28 @@ class Primitives:
         '''a scalar number'''
 
     @primitive(precedence=0)
-    def index(value: AbstractIndex):
+    def tensor(abstract: AbstractTensor):
+        '''an abstract tensor'''
+
+    @primitive(precedence=0)
+    def index(item: AbstractIndex):
         '''an index'''
 
     @primitive(precedence=0)
-    def tensor(value: AbstractTensor):
-        '''an abstract tensor'''
+    def indices(items: Tuple[AbstractIndex]):
+        '''a tuple of indices'''
 
     @primitive(precedence=1)
-    def index_notation(
-        tensor: _ASNode,
-        indices: Union[AbstractIndex, Iterable[AbstractIndex]]
-    ):
-        '''indexed notation for a single tensor'''
+    def index_notation(tensor: _ASNode, indices: _ASNode):
+        '''indexed notation for a single tensor: tensor[indices...]'''
 
     @primitive(precedence=2)
     def call(f: str, x: _ASNode):
-        '''nonlinear function call'''
+        '''general function call: f(x)'''
 
     @primitive(precedence=3)
     def pow(base: _ASNode, exponent: _ASNode):
-        '''raise to power'''
+        '''raise to power: base**exponent'''
 
     @primitive(precedence=4)
     def neg(x: _ASNode):
@@ -66,19 +67,23 @@ class Primitives:
 
     @primitive(precedence=5)
     def mul(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise multiplication, Hadamard product'''
+        '''multiplication'''
 
     @primitive(precedence=5)
     def div(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise division'''
+        '''division'''
 
     @primitive(precedence=6)
     def add(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise addition'''
+        '''addition'''
 
     @primitive(precedence=6)
     def sub(lhs: _ASNode, rhs: _ASNode):
-        '''elementwise subtraction'''
+        '''subtraction'''
+
+    @primitive(precedence=7)
+    def let(src: _ASNode, indices: _ASNode):
+        '''explicit specify output indices'''
 
     @classmethod
     def as_primitive(cls, value):

--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -3,7 +3,7 @@
 from dataclasses import make_dataclass
 import inspect
 from numbers import Real
-from typing import Tuple
+from typing import Optional, Tuple
 from ._tensor import AbstractIndex, AbstractTensor
 
 
@@ -13,7 +13,7 @@ class _ASNode:
 
 class Primitives:
 
-    def primitive(precedence):
+    def primitive(precedence=None):
         def make_primitive(f):
             args = inspect.getfullargspec(f).args
             p = make_dataclass(
@@ -22,7 +22,8 @@ class Primitives:
                 bases=(_ASNode,)
             )
             p.name = property(lambda self: f.__name__)
-            p.precedence = property(lambda self: precedence)
+            if precedence is not None:
+                p.precedence = property(lambda self: precedence)
             p.fields = property(lambda self: self.__dict__)
             p.fields_fixed = property(lambda self: {
                 k: v for k, v in self.__dict__.items() if k in args
@@ -65,25 +66,12 @@ class Primitives:
     def neg(x: _ASNode):
         '''elementwise negation'''
 
-    @primitive(precedence=5)
-    def mul(lhs: _ASNode, rhs: _ASNode):
-        '''multiplication'''
-
-    @primitive(precedence=5)
-    def div(lhs: _ASNode, rhs: _ASNode):
-        '''division'''
-
-    @primitive(precedence=6)
-    def add(lhs: _ASNode, rhs: _ASNode):
-        '''addition'''
-
-    @primitive(precedence=6)
-    def sub(lhs: _ASNode, rhs: _ASNode):
-        '''subtraction'''
-
-    @primitive(precedence=7)
-    def let(src: _ASNode, indices: _ASNode):
-        '''explicit specify output indices'''
+    @primitive(precedence=None)
+    def ein(
+        lhs: _ASNode, rhs: _ASNode, precedence: int,
+        reduction: str, pairwise: str, outidx: Optional[_ASNode]
+    ):
+        '''pairwise einsum-like operations between tensors'''
 
     @classmethod
     def as_primitive(cls, value):

--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -81,17 +81,17 @@ class Primitives:
             return cls.scalar(value=value)
         else:
             raise TypeError(
-                f'Cannot use {value} of type {type(value)} in'
-                'a tensor expression.'
+                f'Cannot use {value} of type {type(value)} in '
+                f'a tensor expression.'
             )
 
 
 class _AST:
 
     def __init__(self, data=None):
-        if isinstance(data, type(self)):
+        try:  # copy-construct from another AST
             self.root = data.root
-        else:
+        except AttributeError:
             try:
                 self.root = Primitives.as_primitive(data)
             except TypeError:
@@ -106,11 +106,3 @@ class _AST:
     @root.setter
     def root(self, r):
         self._root = r
-
-    @classmethod
-    def _as_tree(cls, t):
-        return cls(t)
-
-    @classmethod
-    def _as_node(cls, t):
-        return cls._as_tree(t).root

--- a/funfact/lang/_semiring.py
+++ b/funfact/lang/_semiring.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from ._ast import Primitives as P
+from ._tsrex import TsrEx, EinopEx
+
+
+def minplus(lhs: TsrEx, rhs: TsrEx):
+    return EinopEx(P.ein(
+        lhs._as_node(lhs), rhs._as_node(rhs), 6, 'min', 'add', None
+    ))

--- a/funfact/lang/_tensor.py
+++ b/funfact/lang/_tensor.py
@@ -17,16 +17,20 @@ class Identifier(ABC):
     @symbol.setter
     def symbol(self, string: str):
         m = re.fullmatch(r'([a-zA-Z]+)(?:_(\d+))?', string)
-        if m is None:
-            raise RuntimeError(
-                f'{repr(string)} is not a valid symbol.\n'
-                'A symbol must be alphabetic and optionally followed by an '
-                'underscore and a numeric subscript. '
-                'Examples: i, j, k_0, lhs, etc.'
-            )
-        self._letter, self._number = m.groups()
-        if self._letter == 'Anonymous':
-            self._letter = r'\varphi'
+        try:
+            self._letter, self._number = m.groups()
+        except AttributeError:
+            m = re.fullmatch(r'__(\d+)', string)
+            try:
+                self._letter = r'\lambda'
+                self._number, = m.groups()
+            except AttributeError:
+                raise RuntimeError(
+                    f'{repr(string)} is not a valid symbol.\n'
+                    'A symbol must be alphabetic and optionally followed by '
+                    'an underscore and a numeric subscript. '
+                    'Examples: i, j, k_0, lhs, etc.'
+                )
 
     @abstractmethod
     def _repr_tex_(self):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -55,52 +55,52 @@ class ArithmeticMixin:
 
     def __add__(self, rhs):
         return EinopEx(P.ein(
-            self.root, self._as_node(rhs), 6, 'sum', 'add', None
+            self.root, _BaseEx(rhs).root, 6, 'sum', 'add', None
         ))
 
     def __radd__(self, lhs):
         return EinopEx(P.ein(
-            self._as_node(lhs), self.root, 6, 'sum', 'add', None
+            _BaseEx(lhs).root, self.root, 6, 'sum', 'add', None
         ))
 
     def __sub__(self, rhs):
         return EinopEx(P.ein(
-            self.root, self._as_node(rhs), 6, 'sum', 'sub', None
+            self.root, _BaseEx(rhs).root, 6, 'sum', 'sub', None
         ))
 
     def __rsub__(self, lhs):
         return EinopEx(P.ein(
-            self._as_node(lhs), self.root, 6, 'sum', 'sub', None
+            _BaseEx(lhs).root, self.root, 6, 'sum', 'sub', None
         ))
 
     def __mul__(self, rhs):
         return EinopEx(P.ein(
-            self.root, self._as_node(rhs), 5, 'sum', 'mul', None
+            self.root, _BaseEx(rhs).root, 5, 'sum', 'mul', None
         ))
 
     def __rmul__(self, lhs):
         return EinopEx(P.ein(
-            self._as_node(lhs), self.root, 5, 'sum', 'mul', None
+            _BaseEx(lhs).root, self.root, 5, 'sum', 'mul', None
         ))
 
     def __div__(self, rhs):
         return EinopEx(P.ein(
-            self.root, self._as_node(rhs), 5, 'sum', 'div', None
+            self.root, _BaseEx(rhs).root, 5, 'sum', 'div', None
         ))
 
     def __rdiv__(self, lhs):
         return EinopEx(P.ein(
-            self._as_node(lhs), self.root, 5, 'sum', 'div', None
+            _BaseEx(lhs).root, self.root, 5, 'sum', 'div', None
         ))
 
     def __neg__(self):
         return TsrEx(P.neg(self.root))
 
     def __pow__(self, exponent):
-        return TsrEx(P.pow(self.root, self._as_node(exponent)))
+        return TsrEx(P.pow(self.root, _BaseEx(exponent).root))
 
     def __rpow__(self, base):
-        return TsrEx(P.pow(self._as_node(base)), self.root)
+        return TsrEx(P.pow(_BaseEx(base).root, self.root))
 
 
 class TsrEx(_BaseEx, ArithmeticMixin):
@@ -186,9 +186,3 @@ def tensor(*spec, initializer=None):
     return TensorEx(P.tensor(
         AbstractTensor(symbol, *size, initializer=initializer))
     )
-
-
-def minplus(lhs: TsrEx, rhs: TsrEx):
-    return EinopEx(P.ein(
-        lhs._as_node(lhs), rhs._as_node(rhs), 6, 'min', 'add', None
-    ))

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import re
-import typing
 import asciitree
 from funfact.util.iterable import as_namedtuple, as_tuple, flatten_if
 from funfact.util.typing import _is_tensor

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -9,9 +9,13 @@ from .interpreter import ASCIIRenderer, LatexRenderer
 from ._tensor import AbstractTensor, AbstractIndex
 
 
-class TsrEx(_AST):
+class _BaseEx(_AST):
 
     _latex_intr = LatexRenderer()
+
+    def _repr_html_(self):
+        return f'''$${self._latex_intr(self.root)}$$'''
+
     _ascii_intr = ASCIIRenderer()
     _asciitree = asciitree.LeftAligned(
         traverse=as_namedtuple(
@@ -46,41 +50,70 @@ class TsrEx(_AST):
     def asciitree(self):
         return self._asciitree(self._ascii_intr(self.root))
 
-    def _repr_html_(self):
-        return f'''$${self._latex_intr(self.root)}$$'''
+
+class ArithmeticMixin:
 
     def __add__(self, rhs):
-        return self._as_tree(P.add(self.root, self._as_node(rhs)))
+        return EinopEx(P.ein(
+            self.root, self._as_node(rhs), 6, 'sum', 'add', None
+        ))
 
     def __radd__(self, lhs):
-        return self._as_tree(P.add(self._as_node(lhs), self.root))
+        return EinopEx(P.ein(
+            self._as_node(lhs), self.root, 6, 'sum', 'add', None
+        ))
 
     def __sub__(self, rhs):
-        return self._as_tree(P.sub(self.root, self._as_node(rhs)))
+        return EinopEx(P.ein(
+            self.root, self._as_node(rhs), 6, 'sum', 'sub', None
+        ))
 
     def __rsub__(self, lhs):
-        return self._as_tree(P.sub(self._as_node(lhs), self.root))
+        return EinopEx(P.ein(
+            self._as_node(lhs), self.root, 6, 'sum', 'sub', None
+        ))
 
     def __mul__(self, rhs):
-        return self._as_tree(P.mul(self.root, self._as_node(rhs)))
+        return EinopEx(P.ein(
+            self.root, self._as_node(rhs), 5, 'sum', 'mul', None
+        ))
 
     def __rmul__(self, lhs):
-        return self._as_tree(P.mul(self._as_node(lhs), self.root))
+        return EinopEx(P.ein(
+            self._as_node(lhs), self.root, 5, 'sum', 'mul', None
+        ))
 
     def __div__(self, rhs):
-        return self._as_tree(P.div(self.root, self._as_node(rhs)))
+        return EinopEx(P.ein(
+            self.root, self._as_node(rhs), 5, 'sum', 'div', None
+        ))
 
     def __rdiv__(self, lhs):
-        return self._as_tree(P.div(self._as_node(lhs), self.root))
+        return EinopEx(P.ein(
+            self._as_node(lhs), self.root, 5, 'sum', 'div', None
+        ))
 
     def __neg__(self):
-        return self._as_tree(P.neg(self.root))
+        return TsrEx(P.neg(self.root))
 
     def __pow__(self, exponent):
-        return self._as_tree(P.pow(self.root, self._as_node(exponent)))
+        return TsrEx(P.pow(self.root, self._as_node(exponent)))
 
     def __rpow__(self, base):
-        return self._as_tree(P.pow(self._as_node(base)), self.root)
+        return TsrEx(P.pow(self._as_node(base)), self.root)
+
+
+class TsrEx(_BaseEx, ArithmeticMixin):
+
+    pass
+
+
+class IndexEx(_BaseEx):
+
+    pass
+
+
+class TensorEx(_BaseEx):
 
     def __getitem__(self, indices):
         return TsrEx(
@@ -92,19 +125,18 @@ class TsrEx(_AST):
             )
         )
 
+
+class EinopEx(TsrEx):
+
     def __rshift__(self, output_indices):
-        return TsrEx(
-            P.let(
-                self.root,
-                P.indices(
-                    tuple([i.root for i in as_tuple(output_indices)])
-                )
-            )
+        self.root.outidx = P.indices(
+            tuple([i.root for i in as_tuple(output_indices)])
         )
+        return self
 
 
 def index(symbol):
-    return TsrEx(P.index(AbstractIndex(symbol)))
+    return IndexEx(P.index(AbstractIndex(symbol)))
 
 
 def indices(symbols):
@@ -131,7 +163,7 @@ def tensor(*spec, initializer=None):
 
     Returns
     -------
-    tsrex: TsrEx
+    tsrex: _BaseEx
         A tensor expression representing a single tensor object.
     '''
     if len(spec) == 2 and isinstance(spec[0], str) and _is_tensor(spec[1]):
@@ -151,6 +183,12 @@ def tensor(*spec, initializer=None):
         AbstractTensor.n_nameless += 1
         size = spec
 
-    return TsrEx(P.tensor(
+    return TensorEx(P.tensor(
         AbstractTensor(symbol, *size, initializer=initializer))
     )
+
+
+def minplus(lhs: TsrEx, rhs: TsrEx):
+    return EinopEx(P.ein(
+        lhs._as_node(lhs), rhs._as_node(rhs), 6, 'min', 'add', None
+    ))

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -13,18 +13,20 @@ class ASCIIRenderer(TranscribeInterpreter):
         return str(value)
 
     @as_payload
-    def tensor(self, value, **kwargs):
-        return value.symbol
+    def tensor(self, abstract, **kwargs):
+        return abstract.symbol
 
     @as_payload
-    def index(self, value, **kwargs):
-        return value.symbol
+    def index(self, item, **kwargs):
+        return item.symbol
+
+    @as_payload
+    def indices(self, items, **kwargs):
+        return ','.join([i.ascii for i in items])
 
     @as_payload
     def index_notation(self, tensor, indices, **kwargs):
-        return '{}[{}]'.format(
-            tensor.ascii, ','.join([i.ascii for i in indices])
-        )
+        return f'{tensor.ascii}[{indices.ascii}]'
 
     @as_payload
     def call(self, f, x, **kwargs):
@@ -53,3 +55,7 @@ class ASCIIRenderer(TranscribeInterpreter):
     @as_payload
     def sub(self, lhs, rhs, **kwargs):
         return '-'
+
+    @as_payload
+    def let(self, src, indices, **kwargs):
+        return '>>'

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -41,21 +41,6 @@ class ASCIIRenderer(TranscribeInterpreter):
         return '-'
 
     @as_payload
-    def div(self, lhs, rhs, **kwargs):
-        return '/'
-
-    @as_payload
-    def mul(self, lhs, rhs, **kwargs):
-        return '*'
-
-    @as_payload
-    def add(self, lhs, rhs, **kwargs):
-        return '+'
-
-    @as_payload
-    def sub(self, lhs, rhs, **kwargs):
-        return '-'
-
-    @as_payload
-    def let(self, src, indices, **kwargs):
-        return '>>'
+    def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, **kwargs):
+        suffix = f' -> {outidx.ascii}' if outidx is not None else ''
+        return f'{reduction}:{pairwise}' + suffix

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 import copy
 from numbers import Real
-from typing import Any, Callable, Iterable, Tuple, Union
+from typing import Any, Callable, Iterable, Optional, Tuple, Union
 from funfact.lang._ast import _ASNode, _AST, Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor
 from funfact.util.iterable import flatten_if
@@ -78,23 +78,8 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
-    def mul(self, lhs: Any, rhs: Any, **payload: Any):
-        pass
-
-    @abstractmethod
-    def div(self, lhs: Any, rhs: Any, **payload: Any):
-        pass
-
-    @abstractmethod
-    def add(self, lhs: Any, rhs: Any, **payload: Any):
-        pass
-
-    @abstractmethod
-    def sub(self, lhs: Any, rhs: Any, **payload: Any):
-        pass
-
-    @abstractmethod
-    def let(self, src: Any, indices: Any, **payload: Any):
+    def ein(self, lhs: Any, rhs: Any, precedence: int, reduction: str,
+            pairwise: str, outidx: Any, **payload: Any):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):
@@ -113,8 +98,7 @@ class TranscribeInterpreter(ABC):
     '''A transcribe interpreter creates a modified copy of an AST while
     traversing it.'''
     Tensorial = Union[
-        P.index_notation, P.call, P.pow, P.neg, P.mul, P.div, P.add, P.sub,
-        P.let
+        P.index_notation, P.call, P.pow, P.neg, P.ein
     ]
     Numeric = Union[Tensorial, Real]
 
@@ -160,23 +144,8 @@ class TranscribeInterpreter(ABC):
         pass
 
     @abstractmethod
-    def mul(self, lhs: Numeric, rhs: Numeric, **payload: Any):
-        pass
-
-    @abstractmethod
-    def div(self, lhs: Numeric, rhs: Numeric, **payload: Any):
-        pass
-
-    @abstractmethod
-    def add(self, lhs: Numeric, rhs: Numeric, **payload: Any):
-        pass
-
-    @abstractmethod
-    def sub(self, lhs: Numeric, rhs: Numeric, **payload: Any):
-        pass
-
-    @abstractmethod
-    def let(self, src: Numeric, indices: P.indices, **payload: Any):
+    def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
+            pairwise: str, outidx: Optional[P.indices], **payload: Any):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 import copy
 from numbers import Real
-from typing import Any, Callable, Iterable, Union
+from typing import Any, Callable, Iterable, Tuple, Union
 from funfact.lang._ast import _ASNode, _AST, Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor
 from funfact.util.iterable import flatten_if
@@ -48,11 +48,15 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
-    def tensor(self, value: AbstractTensor, **payload: Any):
+    def tensor(self, abstract: AbstractTensor, **payload: Any):
         pass
 
     @abstractmethod
-    def index(self, value: AbstractIndex, **payload: Any):
+    def index(self, item: AbstractIndex, **payload: Any):
+        pass
+
+    @abstractmethod
+    def indices(self, items: AbstractIndex, **payload: Any):
         pass
 
     @abstractmethod
@@ -89,6 +93,10 @@ class ROOFInterpreter(ABC):
     def sub(self, lhs: Any, rhs: Any, **payload: Any):
         pass
 
+    @abstractmethod
+    def let(self, src: Any, indices: Any, **payload: Any):
+        pass
+
     def __call__(self, node: _ASNode, parent: _ASNode = None):
         fields_fixed = {
             name: _deep_apply(self, value, node)
@@ -105,7 +113,8 @@ class TranscribeInterpreter(ABC):
     '''A transcribe interpreter creates a modified copy of an AST while
     traversing it.'''
     Tensorial = Union[
-        P.index_notation, P.call, P.pow, P.neg, P.mul, P.div, P.add, P.sub
+        P.index_notation, P.call, P.pow, P.neg, P.mul, P.div, P.add, P.sub,
+        P.let
     ]
     Numeric = Union[Tensorial, Real]
 
@@ -121,16 +130,20 @@ class TranscribeInterpreter(ABC):
         pass
 
     @abstractmethod
-    def tensor(self, value: AbstractTensor, **payload: Any):
+    def tensor(self, abstract: AbstractTensor, **payload: Any):
         pass
 
     @abstractmethod
-    def index(self, value: AbstractIndex, **payload: Any):
+    def index(self, item: AbstractIndex, **payload: Any):
+        pass
+
+    @abstractmethod
+    def indices(self, items: Tuple[AbstractIndex], **payload: Any):
         pass
 
     @abstractmethod
     def index_notation(
-        self, tensor: P.tensor, indices: Iterable[P.index], **payload: Any
+        self, tensor: P.tensor, indices: P.indices, **payload: Any
     ):
         pass
 
@@ -160,6 +173,10 @@ class TranscribeInterpreter(ABC):
 
     @abstractmethod
     def sub(self, lhs: Numeric, rhs: Numeric, **payload: Any):
+        pass
+
+    @abstractmethod
+    def let(self, src: Numeric, indices: P.indices, **payload: Any):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):

--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -5,7 +5,17 @@ import numpy
 import re
 
 
-def _einop(spec: str, lhs, rhs, op):
+class DummyBackend:
+
+    add = np.add
+    sub = np.subtract
+    mul = np.multiply
+    div = np.divide
+    min = np.min
+    sum = np.sum
+
+
+def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
     '''Einstein operation between two nd arrays.
 
     Parameters
@@ -22,8 +32,10 @@ def _einop(spec: str, lhs, rhs, op):
         Left hand side array
     rhs: array
         Right hand side array
-    op: callable
-        Numpy function for Einstein operation
+    reduction: str
+        Name of the reduction operator
+    pairwise: str
+        Name of the pairwise operator
     '''
 
     # parse input spec string
@@ -67,7 +79,11 @@ def _einop(spec: str, lhs, rhs, op):
     con_ax = tuple(con_ax)
 
     # compute the contraction in alphabetical order
-    result = np.sum(op(lhs[dim_lhs], rhs[dim_rhs]), axis=con_ax)
+    op_redu = getattr(DummyBackend, reduction)
+    op_pair = getattr(DummyBackend, pairwise)
+
+    print('op_redu', op_redu)
+    result = op_redu(op_pair(lhs[dim_lhs], rhs[dim_rhs]), axis=con_ax)
 
     # reorder contraction according to res_spec
     dictionary = dict(zip(indices_rem, numpy.arange(len(indices_rem))))

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from numbers import Real
-from typing import Tuple
+from typing import Optional, Tuple
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor
@@ -39,7 +39,7 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
         return None
 
     @as_payload
-    def tensor(self, value: AbstractTensor, **kwargs):
+    def tensor(self, abstract: AbstractTensor, **kwargs):
         return None
 
     @as_payload
@@ -68,30 +68,9 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
         return None
 
     @as_payload
-    def mul(self, lhs: Numeric, rhs: Numeric, live_indices, **kwargs):
+    def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
+            pairwise: str, outidx: Optional[P.indices], live_indices,
+            **kwargs):
         map = IndexMap()
         return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
                f'->{map(live_indices)}'
-
-    @as_payload
-    def div(self, lhs: Numeric, rhs: Numeric, live_indices, **kwargs):
-        map = IndexMap()
-        return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
-               f'->{map(live_indices)}'
-
-    @as_payload
-    def add(self, lhs: Numeric, rhs: Numeric, live_indices, **kwargs):
-        map = IndexMap()
-        return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
-               f'->{map(live_indices)}'
-
-    @as_payload
-    def sub(self, lhs: Numeric, rhs: Numeric, live_indices, **kwargs):
-        map = IndexMap()
-        return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
-               f'->{map(live_indices)}'
-
-    @as_payload
-    def let(self, src: Numeric, indices: P.indices, live_indices, **kwargs):
-        map = IndexMap()
-        return f'{map(src.live_indices)}->{map(live_indices)}'

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from numbers import Real
-from typing import Iterable, Union
+from typing import Tuple, Union
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor
@@ -29,10 +29,8 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
     '''The Einstein summation specification generator creates NumPy-style spec
     strings for tensor contraction operations.'''
 
-    Tensorial = Union[
-        P.index_notation, P.call, P.pow, P.neg, P.mul, P.div, P.add, P.sub
-    ]
-    Numeric = Union[Tensorial, Real]
+    Tensorial = TranscribeInterpreter.Tensorial
+    Numeric = TranscribeInterpreter.Numeric
 
     as_payload = TranscribeInterpreter.as_payload('einspec')
 
@@ -45,13 +43,15 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
         return None
 
     @as_payload
-    def index(self, value: AbstractIndex, **kwargs):
+    def index(self, item: AbstractIndex, **kwargs):
         return None
 
     @as_payload
-    def index_notation(
-        self, tensor: P.tensor, indices: Iterable[P.index],  **kwargs
-    ):
+    def indices(self, items: Tuple[P.index], **kwargs):
+        return None
+
+    @as_payload
+    def index_notation(self, tensor: P.tensor, indices: P.indices,  **kwargs):
         return None
 
     @as_payload
@@ -90,3 +90,8 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
         map = IndexMap()
         return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
                f'->{map(live_indices)}'
+
+    @as_payload
+    def let(self, src: Numeric, indices: P.indices, live_indices, **kwargs):
+        map = IndexMap()
+        return f'{map(src.live_indices)}->{map(live_indices)}'

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from numbers import Real
-from typing import Tuple, Union
+from typing import Tuple
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -16,10 +16,13 @@ class Evaluator(ROOFInterpreter):
     def scalar(self, value, **kwargs):
         return value
 
-    def tensor(self, value, data, **kwargs):
+    def tensor(self, abstract, data, **kwargs):
         return data
 
-    def index(self, value, **kwargs):
+    def index(self, item, **kwargs):
+        return None
+
+    def indices(self, items, **kwargs):
         return None
 
     def index_notation(self, tensor, indices, **kwargs):
@@ -45,3 +48,7 @@ class Evaluator(ROOFInterpreter):
 
     def sub(self, lhs, rhs, einspec, **kwargs):
         return self._binary_operator(np.subtract, lhs, rhs, einspec)
+
+    def let(self, src, indices, einspec, **kwargs):
+        src_spec, dst_spec = einspec.split('->')
+        return np.transpose(src, [src_spec.index(i) for i in dst_spec])

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -10,8 +10,8 @@ class Evaluator(ROOFInterpreter):
     '''
 
     @staticmethod
-    def _binary_operator(op, lhs, rhs, spec):
-        return _einop(spec, lhs, rhs, op)
+    def _binary_operator(reduction, pairwise, lhs, rhs, spec):
+        return _einop(spec, lhs, rhs, reduction, pairwise)
 
     def scalar(self, value, **kwargs):
         return value
@@ -37,18 +37,6 @@ class Evaluator(ROOFInterpreter):
     def neg(self, x, **kwargs):
         return -x
 
-    def div(self, lhs, rhs, einspec, **kwargs):
-        return self._binary_operator(np.divide, lhs, rhs, einspec)
-
-    def mul(self, lhs, rhs, einspec, **kwargs):
-        return self._binary_operator(np.multiply, lhs, rhs, einspec)
-
-    def add(self, lhs, rhs, einspec, **kwargs):
-        return self._binary_operator(np.add, lhs, rhs, einspec)
-
-    def sub(self, lhs, rhs, einspec, **kwargs):
-        return self._binary_operator(np.subtract, lhs, rhs, einspec)
-
-    def let(self, src, indices, einspec, **kwargs):
-        src_spec, dst_spec = einspec.split('->')
-        return np.transpose(src, [src_spec.index(i) for i in dst_spec])
+    def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, einspec,
+            **kwargs):
+        return self._binary_operator(reduction, pairwise, lhs, rhs, einspec)

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import itertools as it
 from numbers import Real
-from typing import Union
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -2,15 +2,11 @@
 # -*- coding: utf-8 -*-
 import itertools as it
 from numbers import Real
+from typing import Optional
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor
-
-
-def ordered_symmetric_difference(lhs_indices, rhs_indices):
-    diff_lhs = [x for x in lhs_indices if x not in rhs_indices]
-    diff_rhs = [x for x in rhs_indices if x not in lhs_indices]
-    return diff_lhs + diff_rhs
+from funfact.util.set import ordered_symmdiff
 
 
 class IndexPropagator(TranscribeInterpreter):
@@ -57,21 +53,9 @@ class IndexPropagator(TranscribeInterpreter):
         return x.live_indices
 
     @as_payload
-    def mul(self, lhs: Numeric, rhs: Numeric, **kwargs):
-        return ordered_symmetric_difference(lhs.live_indices, rhs.live_indices)
-
-    @as_payload
-    def div(self, lhs: Numeric, rhs: Numeric, **kwargs):
-        return ordered_symmetric_difference(lhs.live_indices, rhs.live_indices)
-
-    @as_payload
-    def add(self, lhs: Numeric, rhs: Numeric, **kwargs):
-        return ordered_symmetric_difference(lhs.live_indices, rhs.live_indices)
-
-    @as_payload
-    def sub(self, lhs: Numeric, rhs: Numeric, **kwargs):
-        return ordered_symmetric_difference(lhs.live_indices, rhs.live_indices)
-
-    @as_payload
-    def let(self, src: Numeric, indices: P.indices, **kwargs):
-        return indices.live_indices
+    def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
+            pairwise: str, outidx: Optional[P.indices], **kwargs):
+        if outidx is not None:
+            return outidx.live_indices
+        else:
+            return ordered_symmdiff(lhs.live_indices, rhs.live_indices)

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -64,21 +64,5 @@ class LeafInitializer(TranscribeInterpreter):
         return None
 
     @as_payload
-    def div(self, lhs, rhs, **kwargs):
-        return None
-
-    @as_payload
-    def mul(self, lhs, rhs, **kwargs):
-        return None
-
-    @as_payload
-    def add(self, lhs, rhs, **kwargs):
-        return None
-
-    @as_payload
-    def sub(self, lhs, rhs, **kwargs):
-        return None
-
-    @as_payload
-    def let(self, dst, src, **kwargs):
+    def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, **kwargs):
         return None

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -29,18 +29,22 @@ class LeafInitializer(TranscribeInterpreter):
         return None
 
     @as_payload
-    def tensor(self, value, **kwargs):
-        if value.initializer is not None:
-            if not callable(value.initializer):
-                return copy.deepcopy(value.initializer)
-            ini = value.initializer
+    def tensor(self, abstract, **kwargs):
+        if abstract.initializer is not None:
+            if not callable(abstract.initializer):
+                init_val = copy.deepcopy(abstract.initializer)
+            else:
+                init_val = abstract.initializer(abstract.shape)
         else:
-            def ini(shape):
-                return self.rng.normal(shape)
-        return ini(value.shape)
+            init_val = self.rng.normal(abstract.shape)
+        return init_val
 
     @as_payload
-    def index(self, value, **kwargs):
+    def index(self, item, **kwargs):
+        return None
+
+    @as_payload
+    def indices(self, items, **kwargs):
         return None
 
     @as_payload
@@ -73,4 +77,8 @@ class LeafInitializer(TranscribeInterpreter):
 
     @as_payload
     def sub(self, lhs, rhs, **kwargs):
+        return None
+
+    @as_payload
+    def let(self, dst, src, **kwargs):
         return None

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -3,6 +3,15 @@
 from ._base import ROOFInterpreter
 
 
+_omap = dict(
+    add='+',
+    sub='-',
+    mul=r'\times',
+    div='/',
+    min=r'\min'
+)
+
+
 class LatexRenderer(ROOFInterpreter):
 
     def __call__(self, node, parent=None):
@@ -39,17 +48,13 @@ class LatexRenderer(ROOFInterpreter):
     def neg(self, x, **kwargs):
         return fr'-{x}'
 
-    def div(self, lhs, rhs, **kwargs):
-        return fr'{lhs} / {rhs}'
-
-    def mul(self, lhs, rhs, **kwargs):
-        return fr'{lhs} \times {rhs}'
-
-    def add(self, lhs, rhs, **kwargs):
-        return fr'{lhs} + {rhs}'
-
-    def sub(self, lhs, rhs, **kwargs):
-        return fr'{lhs} - {rhs}'
-
-    def let(self, src, indices, **kwargs):
-        return fr'''{{{src}}}\rightarrow_{{{indices}}}'''
+    def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, **kwargs):
+        if reduction == 'sum':
+            op = _omap[pairwise]
+        else:
+            op = r'\underset{{{}:{}}}{{\star}}'.format(
+                _omap[reduction], _omap[pairwise]
+            )
+        body = fr'{lhs} {op} {rhs}'
+        suffix = fr'\rightarrow_{{{outidx}}}' if outidx is not None else ''
+        return body + suffix

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -18,14 +18,17 @@ class LatexRenderer(ROOFInterpreter):
     def scalar(self, value, **kwargs):
         return str(value)
 
-    def tensor(self, value, **kwargs):
-        return value._repr_tex_()
+    def tensor(self, abstract, **kwargs):
+        return abstract._repr_tex_()
 
-    def index(self, value, **kwargs):
-        return value._repr_tex_()
+    def index(self, item, **kwargs):
+        return item._repr_tex_()
+
+    def indices(self, items, **kwargs):
+        return ''.join(items)
 
     def index_notation(self, tensor, indices, **kwargs):
-        return fr'''{{{tensor}}}_{{{''.join(indices)}}}'''
+        return fr'''{{{tensor}}}_{{{indices}}}'''
 
     def call(self, f, x, **kwargs):
         return fr'\operatorname{{{f}}}{{{x}}}'
@@ -47,3 +50,6 @@ class LatexRenderer(ROOFInterpreter):
 
     def sub(self, lhs, rhs, **kwargs):
         return fr'{lhs} - {rhs}'
+
+    def let(self, src, indices, **kwargs):
+        return fr'''{{{src}}}\rightarrow_{{{indices}}}'''

--- a/funfact/lang/interpreter/_syntax_validation.py
+++ b/funfact/lang/interpreter/_syntax_validation.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from funfact.lang._ast import _ASNode, _AST, Primitives as P
+from ._base import _deep_apply
+
+
+class SyntaxValidator:
+    '''A ROOF (Read-Only On-the-Fly) interpreter traverses an AST for one pass
+    and produces the final outcome without altering the AST. Intermediates are
+    passed as return values between the traversing levels. Its primitive rules
+    may still accept a 'payload' argument, which could be potentially produced
+    by another transcribe interpreter.'''
+
+    def scalar(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def tensor(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def index(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def indices(self, node: _ASNode, parent: _ASNode):
+        for i in node.items:
+            if not isinstance(i, P.index):
+                raise SyntaxError('Non-index item {i} found in indices.')
+
+    def index_notation(self, node: _ASNode, parent: _ASNode):
+        if not isinstance(node.tensor, P.tensor):
+            raise SyntaxError(
+                f'Index notation only applies to a tensor object, '
+                f'got {node.tensor} instead.'
+            )
+        if len(node.indices.items) != node.tensor.value.ndim:
+            raise SyntaxError(
+                f'Number of indices in {node.indices.items} does not match '
+                f'the rank of tensor {node.tensor}.'
+            )
+
+    def call(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def pow(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def neg(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def mul(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def div(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def add(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def sub(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def let(self, node: _ASNode, parent: _ASNode):
+        pass
+
+    def __call__(self, node: _ASNode, parent: _ASNode = None):
+        for name, value in node.fields_fixed.items():
+            _deep_apply(self, value, node)
+        return getattr(self, node.name)(node, parent)
+
+    def __ror__(self, tsrex: _AST):
+        self(tsrex.root)

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -52,7 +52,7 @@ class Factorization:
         elements.'''
         if isinstance(idx, str):
             for n in dfs_filter(
-                lambda n: n.name == 'tensor' and n.value.symbol == idx,
+                lambda n: n.name == 'tensor' and n.abstract.symbol == idx,
                 self.tsrex.root
             ):
                 return n.data
@@ -67,7 +67,7 @@ class Factorization:
     def __setitem__(self, name, data):
         '''Implements attribute-based access of factor tensors.'''
         for n in dfs_filter(
-            lambda n: n.name == 'tensor' and n.value.symbol == name,
+            lambda n: n.name == 'tensor' and n.abstract.symbol == name,
             self.tsrex.root
         ):
             return setattr(n, 'data', data)

--- a/funfact/util/iterable.py
+++ b/funfact/util/iterable.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from collections import namedtuple
+from typing import Iterable
 
 
 def flatten(iterable):
@@ -90,3 +91,10 @@ def map_or_call(iterable, mapping):
 
 def as_namedtuple(title, **kwargs):
     return namedtuple(title, kwargs.keys())(*kwargs.values())
+
+
+def as_tuple(elements):
+    if isinstance(elements, Iterable):
+        return tuple(elements)
+    else:
+        return (elements,)

--- a/funfact/util/set.py
+++ b/funfact/util/set.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def ordered_union(S, T):
+    return S + [t for t in T if t not in S]
+
+
+def ordered_intersect(S, T):
+    return [s for s in S if s in T]
+
+
+def ordered_setminus(S, T):
+    return [s for s in S if s not in T]
+
+
+def ordered_symmdiff(S, T):
+    S1 = [s for s in S if s not in T]
+    T1 = [t for t in T if t not in S]
+    return S1 + T1


### PR DESCRIPTION
Summary:
- Added the `>>` operator for the explicit specification of output tensor indices.
- A shorthand syntax, which introduces the `~` modifier to individual indices, will be implemented in #17.
- Replaces #16.
- Closes #6.

Example:
```
A = ff.tensor('A', 2, 3)
B = ff.tensor('B', 3, 4)
i, j, k = ff.indices('i, j, k')
tsrex = A[i, j] * B[j, k] >> (k, j)
```
give rise to the following tensor expression
```
 >>
 ├── *
 │   ├── A[i,j]
 │   │   ├── A
 │   │   ╰── i,j
 │   │       ├── i
 │   │       ╰── j
 │   ╰── B[j,k]
 │       ├── B
 │       ╰── j,k
 │           ├── j
 │           ╰── k
 ╰── k,j
     ├── k
     ╰── j
```
which in addition to carrying out the inner product, also transposes the final result.

This is currently a **work-in-progress**: a forward-backward interpreter is needed to implement index analysis for the new syntax.

