### PR TITLE
Implemented the `~`  syntax to indicate an index as non-reducing.

### DIFF
--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -43,7 +43,7 @@ class Primitives:
         '''an abstract tensor'''
 
     @primitive(precedence=0)
-    def index(item: AbstractIndex):
+    def index(item: AbstractIndex, mustkeep: bool):
         '''an index'''
 
     @primitive(precedence=0)

--- a/funfact/lang/_tensor.py
+++ b/funfact/lang/_tensor.py
@@ -51,11 +51,15 @@ class AbstractIndex(Identifier):
     def __repr__(self):
         return f'{type(self).__qualname__}({repr(self.symbol)})'
 
-    def _repr_tex_(self):
-        if self._number is not None:
-            return fr'{{{self._letter}}}_{{{self._number}}}'
+    def _repr_tex_(self, accent=None):
+        if accent is not None:
+            letter = fr'{accent}{{{self._letter}}}'
         else:
-            return fr'{{{self._letter}}}'
+            letter = self._letter
+        if self._number is not None:
+            return fr'{{{letter}}}_{{{self._number}}}'
+        else:
+            return fr'{{{letter}}}'
 
 
 class AbstractTensor(Identifier):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import dataclasses
 import re
 import asciitree
 from funfact.util.iterable import as_namedtuple, as_tuple, flatten_if
@@ -104,17 +105,15 @@ class ArithmeticMixin:
 
 
 class TsrEx(_BaseEx, ArithmeticMixin):
-
     pass
 
 
 class IndexEx(_BaseEx):
-
-    pass
+    def __invert__(self):
+        return IndexEx(dataclasses.replace(self.root, mustkeep=True))
 
 
 class TensorEx(_BaseEx):
-
     def __getitem__(self, indices):
         return TsrEx(
             P.index_notation(
@@ -127,7 +126,6 @@ class TensorEx(_BaseEx):
 
 
 class EinopEx(TsrEx):
-
     def __rshift__(self, output_indices):
         self.root.outidx = P.indices(
             tuple([i.root for i in as_tuple(output_indices)])
@@ -136,7 +134,7 @@ class EinopEx(TsrEx):
 
 
 def index(symbol):
-    return IndexEx(P.index(AbstractIndex(symbol)))
+    return IndexEx(P.index(AbstractIndex(symbol), mustkeep=False))
 
 
 def indices(symbols):

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -17,8 +17,11 @@ class ASCIIRenderer(TranscribeInterpreter):
         return abstract.symbol
 
     @as_payload
-    def index(self, item, **kwargs):
-        return item.symbol
+    def index(self, item, mustkeep, **kwargs):
+        if mustkeep:
+            return f'~{item.symbol}'
+        else:
+            return item.symbol
 
     @as_payload
     def indices(self, items, **kwargs):

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -52,7 +52,7 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
-    def index(self, item: AbstractIndex, **payload: Any):
+    def index(self, item: AbstractIndex, mustkeep: bool, **payload: Any):
         pass
 
     @abstractmethod
@@ -102,12 +102,19 @@ class TranscribeInterpreter(ABC):
     ]
     Numeric = Union[Tensorial, Real]
 
-    def as_payload(k):
-        def wrapper(f):
-            def wrapped_f(*args, **kwargs):
-                return k, f(*args, **kwargs)
-            return wrapped_f
-        return wrapper
+    def as_payload(*k):
+        if len(k) == 1:
+            def wrapper(f):
+                def wrapped_f(*args, **kwargs):
+                    return *k, f(*args, **kwargs)
+                return wrapped_f
+            return wrapper
+        else:
+            def wrapper(f):
+                def wrapped_f(*args, **kwargs):
+                    return dict(zip(k, f(*args, **kwargs)))
+                return wrapped_f
+            return wrapper
 
     @abstractmethod
     def scalar(self, value: Real, **payload: Any):
@@ -118,7 +125,7 @@ class TranscribeInterpreter(ABC):
         pass
 
     @abstractmethod
-    def index(self, item: AbstractIndex, **payload: Any):
+    def index(self, item: AbstractIndex, mustkeep: bool, **payload: Any):
         pass
 
     @abstractmethod

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -6,7 +6,7 @@ from typing import Optional
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor
-from funfact.util.set import ordered_symmdiff
+from funfact.util.set import ordered_symmdiff, ordered_union, ordered_setminus
 
 
 class IndexPropagator(TranscribeInterpreter):
@@ -16,46 +16,73 @@ class IndexPropagator(TranscribeInterpreter):
     Tensorial = TranscribeInterpreter.Tensorial
     Numeric = TranscribeInterpreter.Numeric
 
-    as_payload = TranscribeInterpreter.as_payload('live_indices')
+    as_payload = TranscribeInterpreter.as_payload(
+        'live_indices', 'keep_indices'
+    )
 
     @as_payload
     def scalar(self, value: Real, **kwargs):
-        return []
+        return [], []
 
     @as_payload
     def tensor(self, abstract: AbstractTensor, **kwargs):
-        return []
+        return [], []
 
     @as_payload
-    def index(self, item: AbstractIndex, **kwargs):
-        return [item.symbol]
+    def index(self, item: AbstractIndex, mustkeep: bool, **kwargs):
+        return [item.symbol], [item.symbol] if mustkeep else []
 
     @as_payload
     def indices(self, items: AbstractIndex, **kwargs):
-        return list(it.chain.from_iterable([i.live_indices for i in items]))
+        return (
+            list(it.chain.from_iterable([i.live_indices for i in items])),
+            list(it.chain.from_iterable([i.keep_indices for i in items]))
+        )
 
     @as_payload
     def index_notation(
         self, tensor: P.tensor, indices: P.indices, **kwargs
     ):
-        return indices.live_indices
+        return indices.live_indices, indices.keep_indices
 
     @as_payload
     def call(self, f: str, x: Tensorial, **kwargs):
-        return x.live_indices
+        return x.live_indices, x.keep_indices
 
     @as_payload
     def pow(self, base: Numeric, exponent: Numeric, **kwargs):
-        return base.live_indices + exponent.live_indices
+        return (
+            base.live_indices + exponent.live_indices,
+            base.keep_indices + exponent.keep_indices
+        )
 
     @as_payload
     def neg(self, x: Numeric, **kwargs):
-        return x.live_indices
+        return x.live_indices, x.keep_indices
 
     @as_payload
     def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
             pairwise: str, outidx: Optional[P.indices], **kwargs):
-        if outidx is not None:
-            return outidx.live_indices
+        # indices marked as keep on either side should stay
+        live_indices = ordered_union(lhs.live_indices, rhs.live_indices)
+        keep_indices = ordered_union(lhs.keep_indices, rhs.keep_indices)
+        if outidx is None:
+            lhs_out = [i for i in lhs.live_indices if (i not in rhs.live_indices or i in keep_indices)]
+            rhs_out = [i for i in rhs.live_indices if (i not in lhs.live_indices or i in keep_indices)]
+            implied_out = ordered_union(lhs_out, rhs_out)
+            return implied_out, []
         else:
-            return ordered_symmdiff(lhs.live_indices, rhs.live_indices)
+            explicit_out = outidx.live_indices
+            for i in keep_indices:
+                if i not in explicit_out:
+                    raise SyntaxError(
+                        f'Index {i} is marked as non-reducing, yet is missing '
+                        f'from the explicit output list {explicit_out}.'
+                    )
+            for i in explicit_out:
+                if i not in live_indices:
+                    raise SyntaxError(
+                        f'Explicitly specified index {i} does not'
+                        f'existing in the operand indices list {live_indices}.'
+                    )
+            return explicit_out, []

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -30,8 +30,9 @@ class LatexRenderer(ROOFInterpreter):
     def tensor(self, abstract, **kwargs):
         return abstract._repr_tex_()
 
-    def index(self, item, **kwargs):
-        return item._repr_tex_()
+    def index(self, item, mustkeep, **kwargs):
+        accent = r'\widetilde' if mustkeep else None
+        return fr'{{{item._repr_tex_(accent=accent)}}}'
 
     def indices(self, items, **kwargs):
         return ''.join(items)


### PR DESCRIPTION
Summary:
- Introduced the `~` syntax to exclude indices from einsum reduction operations.
- Closes #17.

Example:
```
A[i, j] * B[j, k] >> (k, j, i)  # OK, j inferred as non-reducing
A[i, ~j] * B[~j, k] >> (k, j, i))  # OK, LHS consistent with RHS
A[i, ~j] * B[j, k]  # OK, j is kept as long as it is marked on either operand
A[i, ~j] * B[~j, k])  # OK
A[i, j] * B[j, k] >> (k, i)  # OK, LHS consistent with RHS, standard einsum
A[~i, j] * B[j, k] >> (k, i)  # OK, i is kept anyway
A[i, ~j] * B[~j, k] >> (k, i))  # WRONG, RHS conflicts with LHS
```
