### PR TITLE
Create tensors and indices without explicitly specifying a name

### DIFF
--- a/funfact/lang/_tensor.py
+++ b/funfact/lang/_tensor.py
@@ -1,36 +1,61 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+import multiprocessing
 import re
 import numbers
+import uuid
 
 
-class Identifier(ABC):
+@dataclass(init=False)
+class Symbol:
 
-    @property
-    def symbol(self):
-        if self._number is not None:
-            return f'{self._letter}_{self._number}'
+    letter: str
+    number: str = None
+
+    def __init__(self, s):
+        if isinstance(s, tuple):
+            self.letter, self.number = s
         else:
-            return self._letter
-
-    @symbol.setter
-    def symbol(self, string: str):
-        m = re.fullmatch(r'([a-zA-Z]+)(?:_(\d+))?', string)
-        try:
-            self._letter, self._number = m.groups()
-        except AttributeError:
-            m = re.fullmatch(r'__(\d+)', string)
+            m = re.fullmatch(r'([a-zA-Z]+)(?:_(\d+))?', s)
             try:
-                self._letter = r'\lambda'
-                self._number, = m.groups()
+                self.letter, self.number = m.groups()
             except AttributeError:
                 raise RuntimeError(
-                    f'{repr(string)} is not a valid symbol.\n'
-                    'A symbol must be alphabetic and optionally followed by '
-                    'an underscore and a numeric subscript. '
-                    'Examples: i, j, k_0, lhs, etc.'
+                    f'{repr(s)} is not a valid symbol, which '
+                    'must be alphabetic and optionally followed by '
+                    'an underscore and a numeric subscript, such as '
+                    'i, j, k_0, lhs, etc.'
                 )
+
+    def __str__(self):
+        if self.number is not None:
+            return f'{self.letter}_{self.number}'
+        else:
+            return self.letter
+
+
+class Identifiable(ABC):
+
+    @staticmethod
+    def _latex_encode(s):
+        if s == '#':
+            return r'\#'
+        elif s == u'λ':
+            return r'\lambda'
+        else:
+            return s
+
+    def __init__(self, symbol: str = None):
+        self.uuid = uuid.uuid4()
+        if symbol is not None:
+            self.symbol = Symbol(symbol)
+        else:
+            self.symbol = self._make_symbol(self.uuid)
+
+    def __hash__(self):
+        return self.uuid.int
 
     @abstractmethod
     def _repr_tex_(self):
@@ -39,11 +64,29 @@ class Identifier(ABC):
     def _repr_html_(self):
         return f'''$${self._repr_tex_()}$$'''
 
+    def __eq__(self, other):
+        return self.uuid == other.uuid
 
-class AbstractIndex(Identifier):
+    @classmethod
+    def _make_symbol(cls, u):
+        with cls._lock:
+            if u in cls._anon_regitry:
+                return cls._anon_regitry[u]
+            else:
+                i = str(len(cls._anon_regitry))
+                cls._anon_regitry[u] = s = Symbol((cls._natural_letter, i))
+                return s
 
-    def __init__(self, symbol):
-        self.symbol = symbol
+
+class AbstractIndex(Identifiable):
+
+    _anon_regitry = {}
+    _lock = multiprocessing.Lock()
+    _natural_letter = '#'
+    '''the default letter to use for anonymous indices.'''
+
+    def __init__(self, symbol=None):
+        super().__init__(symbol)
 
     def __str__(self):
         return str(self.symbol)
@@ -52,17 +95,17 @@ class AbstractIndex(Identifier):
         return f'{type(self).__qualname__}({repr(self.symbol)})'
 
     def _repr_tex_(self, accent=None):
+        letter = self._latex_encode(self.symbol.letter)
+        number = self.symbol.number
         if accent is not None:
-            letter = fr'{accent}{{{self._letter}}}'
-        else:
-            letter = self._letter
-        if self._number is not None:
-            return fr'{{{letter}}}_{{{self._number}}}'
+            letter = fr'{accent}{{{letter}}}'
+        if number is not None:
+            return fr'{{{letter}}}_{{{number}}}'
         else:
             return fr'{{{letter}}}'
 
 
-class AbstractTensor(Identifier):
+class AbstractTensor(Identifiable):
     '''An abstract tensor is a symbolic representation of a multidimensional
     array and is convenient for specifying **tensor expressions**. At
     construction, it does not allocate memory nor populate elements, but rather
@@ -79,10 +122,13 @@ class AbstractTensor(Identifier):
         or tuple.
     '''
 
-    n_nameless = 0
+    _anon_regitry = {}
+    _lock = multiprocessing.Lock()
+    _natural_letter = u'λ'
+    '''the default letter to use for anonymous tensors.'''
 
-    def __init__(self, symbol, *size, initializer=None):
-        self.symbol = symbol
+    def __init__(self, *size, symbol=None, initializer=None):
+        super().__init__(symbol)
         for d, n in enumerate(size):
             if not (isinstance(n, numbers.Integral) and n > 0):
                 raise RuntimeError(
@@ -113,7 +159,9 @@ class AbstractTensor(Identifier):
         )
 
     def _repr_tex_(self):
-        if self._number is not None:
-            return fr'\boldsymbol{{{self._letter}}}^{{({self._number})}}'
+        letter = self._latex_encode(self.symbol.letter)
+        number = self.symbol.number
+        if number is not None:
+            return fr'\boldsymbol{{{letter}}}^{{({number})}}'
         else:
-            return fr'\boldsymbol{{{self._letter}}}'
+            return fr'\boldsymbol{{{letter}}}'

--- a/funfact/lang/_tensor.py
+++ b/funfact/lang/_tensor.py
@@ -38,6 +38,12 @@ class Symbol:
 
 class Identifiable(ABC):
 
+    # to be provisioned by subclasses
+    # TODO: a better apporach is to directly implement a safe dict
+    _anon_regitry: dict
+    _anon_registry_lock: multiprocessing.Lock
+    _natural_letter: str
+
     @staticmethod
     def _latex_encode(s):
         if s == '#':
@@ -69,7 +75,7 @@ class Identifiable(ABC):
 
     @classmethod
     def _make_symbol(cls, u):
-        with cls._lock:
+        with cls._anon_registry_lock:
             if u in cls._anon_regitry:
                 return cls._anon_regitry[u]
             else:
@@ -81,7 +87,7 @@ class Identifiable(ABC):
 class AbstractIndex(Identifiable):
 
     _anon_regitry = {}
-    _lock = multiprocessing.Lock()
+    _anon_registry_lock = multiprocessing.Lock()
     _natural_letter = '#'
     '''the default letter to use for anonymous indices.'''
 
@@ -123,7 +129,7 @@ class AbstractTensor(Identifiable):
     '''
 
     _anon_regitry = {}
-    _lock = multiprocessing.Lock()
+    _anon_registry_lock = multiprocessing.Lock()
     _natural_letter = u'λ'
     '''the default letter to use for anonymous tensors.'''
 

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -133,12 +133,17 @@ class EinopEx(TsrEx):
         return self
 
 
-def index(symbol):
+def index(symbol=None):
     return IndexEx(P.index(AbstractIndex(symbol), mustkeep=False))
 
 
-def indices(symbols):
-    return [index(s) for s in re.split(r'[,\s]+', symbols)]
+def indices(spec):
+    if isinstance(spec, int):
+        return [index() for i in range(spec)]
+    elif isinstance(spec, str):
+        return [index(s) for s in re.split(r'[,\s]+', spec)]
+    else:
+        raise RuntimeError(f'Cannot create indices from {spec}.')
 
 
 def tensor(*spec, initializer=None):
@@ -165,22 +170,23 @@ def tensor(*spec, initializer=None):
         A tensor expression representing a single tensor object.
     '''
     if len(spec) == 2 and isinstance(spec[0], str) and _is_tensor(spec[1]):
+        # name + concrete tensor
         symbol = spec[0]
         initializer = spec[1]
         size = initializer.shape
     elif len(spec) == 1 and _is_tensor(spec[0]):
-        symbol = f'Anonymous_{AbstractTensor.n_nameless}'
-        AbstractTensor.n_nameless += 1
+        # concrete tensor only
+        symbol = None
         initializer = spec[0]
         size = initializer.shape
     elif isinstance(spec[0], str):
+        # name + size
         symbol, *size = spec
     else:
-        # internal format for anonymous symbols
-        symbol = f'__{AbstractTensor.n_nameless}'
-        AbstractTensor.n_nameless += 1
+        # size only
+        symbol = None
         size = spec
 
     return TensorEx(P.tensor(
-        AbstractTensor(symbol, *size, initializer=initializer))
+        AbstractTensor(*size, symbol=symbol, initializer=initializer))
     )

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -14,14 +14,14 @@ class ASCIIRenderer(TranscribeInterpreter):
 
     @as_payload
     def tensor(self, abstract, **kwargs):
-        return abstract.symbol
+        return str(abstract.symbol)
 
     @as_payload
     def index(self, item, mustkeep, **kwargs):
         if mustkeep:
-            return f'~{item.symbol}'
+            return f'~{str(item.symbol)}'
         else:
-            return item.symbol
+            return str(item.symbol)
 
     @as_payload
     def indices(self, items, **kwargs):

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -30,7 +30,7 @@ class IndexPropagator(TranscribeInterpreter):
 
     @as_payload
     def index(self, item: AbstractIndex, mustkeep: bool, **kwargs):
-        return [item.symbol], [item.symbol] if mustkeep else []
+        return [item], [item] if mustkeep else []
 
     @as_payload
     def indices(self, items: AbstractIndex, **kwargs):

--- a/funfact/lang/interpreter/_syntax_validation.py
+++ b/funfact/lang/interpreter/_syntax_validation.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from funfact.lang._ast import _ASNode, _AST, Primitives as P
 from ._base import _deep_apply
+from funfact.util.typing import _is_tensor
 
 
 class SyntaxValidator:
@@ -15,7 +16,14 @@ class SyntaxValidator:
         pass
 
     def tensor(self, node: _ASNode, parent: _ASNode):
-        pass
+        abst = node.abstract
+        ini = node.abstract.initializer
+        if _is_tensor(ini):
+            if ini.shape != abst.shape:
+                raise SyntaxError(
+                    f'The shape {abst.shape} of tensor {abst} does not match '
+                    f'its concrete-tensor initializer of {ini.shape}.'
+                )
 
     def index(self, node: _ASNode, mustkeep: bool, parent: _ASNode):
         pass

--- a/funfact/lang/test_tensor.py
+++ b/funfact/lang/test_tensor.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+import numpy as np
+from ._tensor import AbstractIndex, AbstractTensor
+
+
+def test_abstract_index():
+
+    i = AbstractIndex()
+    j = AbstractIndex()
+    k = AbstractIndex('k_1')
+    assert i == i
+    assert j == j
+    assert k == k
+    assert i != j
+    assert i != k
+    assert j != k
+
+    assert hash(i) != hash(j)
+    assert hash(i) != hash(k)
+    assert hash(j) != hash(k)
+
+    assert isinstance(repr(i), str)
+    assert isinstance(str(i), str)
+    assert isinstance(i._repr_tex_(), str)
+    assert isinstance(i._repr_html_(), str)
+
+
+def test_abstract_tensor():
+
+    u = AbstractTensor(3)
+    v = AbstractTensor(4, 4, initializer=np.eye(4))
+    w = AbstractTensor(9, 2, initializer=np.random.rand)
+    x = AbstractTensor(4, 2, 3, symbol='x')
+    y1 = AbstractTensor(4, 2, 3, symbol='y_1')
+    assert u.ndim == 1
+    assert v.ndim == 2
+    assert w.ndim == 2
+    assert x.ndim == 3
+    assert u.shape == (3,)
+    assert v.shape == (4, 4)
+    assert w.shape == (9, 2)
+    assert x.shape == (4, 2, 3)
+
+    for t in [u, v, w, x, y1]:
+        assert isinstance(repr(t), str)
+        assert isinstance(str(t), str)
+        assert isinstance(t._repr_tex_(), str)
+        assert isinstance(t._repr_html_(), str)

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -52,7 +52,7 @@ class Factorization:
         elements.'''
         if isinstance(idx, str):
             for n in dfs_filter(
-                lambda n: n.name == 'tensor' and n.abstract.symbol == idx,
+                lambda n: n.name == 'tensor' and str(n.abstract.symbol) == idx,
                 self.tsrex.root
             ):
                 return n.data
@@ -67,7 +67,7 @@ class Factorization:
     def __setitem__(self, name, data):
         '''Implements attribute-based access of factor tensors.'''
         for n in dfs_filter(
-            lambda n: n.name == 'tensor' and n.abstract.symbol == name,
+            lambda n: n.name == 'tensor' and str(n.abstract.symbol) == name,
             self.tsrex.root
         ):
             return setattr(n, 'data', data)

--- a/funfact/rbf/_base.py
+++ b/funfact/rbf/_base.py
@@ -104,7 +104,7 @@ class RBFExpansionBasePyCUDA:
 
         @property
         def funrank(self):
-            return len(self.x[-1])
+            return len(self.x[-2])
 
         def __getattr__(self, a):
             return self.x[self.x_names.index(a)]

--- a/funfact/rbf/_dense_stochgrad.py
+++ b/funfact/rbf/_dense_stochgrad.py
@@ -208,7 +208,7 @@ class RBFExpansionDenseStochasticGrad(RBFExpansionBasePyCUDA):
                 thread_per_block=self.cuda_thread_per_block,
                 block_per_inst=self.cuda_block_per_inst
             ),
-            'rbf_expansion_ensemble'
+            'rbf_expansion_ensemble_stochgrad'
         )
 
         def f_cuda(x):


### PR DESCRIPTION
Closes #4.
- Introduced a base class `Identifiable`, which both indices and tensors inherit from. Equality checks between identifiable are performed using UUIDs. The human-readable symbols are now purely for the purpose of visualization and TeX rendering.
- Anonymous indices will be automated assigned a readable symbol in the form of `#_{id}`.
- Anonymous tensors will be automated assigned a readable symbol in the form of `λ_{id}`.

Enabling the following usages:
```python
# Tucker decomposition
T = ff.tensor(3, 3, 3)
u1 = ff.tensor(10, 3)
u2 = ff.tensor(20, 3)
u3 = ff.tensor(30, 3)
i1, i2, i3, k1, k2, k3 = ff.indices(6)
tsrex = T[k1, k2, k3] * u1[i1, k1] * u2[i2, k2] * u3[i3, k3]
tsrex
```
which returns:
```math
{\\boldsymbol{\\lambda}^{(0)}}_{{{\\#}_{3}}{{\\#}_{4}}{{\\#}_{5}}} \\times {\\boldsymbol{\\lambda}^{(1)}}_{{{\\#}_{0}}{{\\#}_{3}}} \\times {\\boldsymbol{\\lambda}^{(2)}}_{{{\\#}_{1}}{{\\#}_{4}}} \\times {\\boldsymbol{\\lambda}^{(3)}}_{{{\\#}_{2}}{{\\#}_{5}}}
```