### PR TITLE
Index renaming

### DIFF
--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -7,7 +7,9 @@ import asciitree
 from funfact.util.iterable import as_namedtuple, as_tuple, flatten_if
 from funfact.util.typing import _is_tensor
 from ._ast import _AST, _ASNode, Primitives as P
-from .interpreter import ASCIIRenderer, LatexRenderer
+from .interpreter import (
+    dfs_filter, ASCIIRenderer, LatexRenderer, IndexPropagator
+)
 from ._tensor import AbstractTensor, AbstractIndex
 
 
@@ -136,7 +138,32 @@ class ArithmeticMixin:
         return TsrEx(P.pow(_BaseEx(base).root, self.root))
 
 
-class TsrEx(_BaseEx, ArithmeticMixin):
+class IndexRenamingMixin:
+
+    def __getitem__(self, indices):
+
+        tsrex = self | IndexPropagator()
+
+        if len(indices) != len(tsrex.root.live_indices):
+            raise SyntaxError(
+                'Incorrect number of indices.'
+            )
+
+        index_map = {}
+        for old, new_expr in zip(tsrex.root.live_indices, indices):
+            if new_expr.root.name != 'index':
+                raise SyntaxError(
+                    'Indices to a tensor expression must be abstract indices.'
+                )
+            index_map[old] = new_expr.root.item
+
+        for n in dfs_filter(lambda n: n.name == 'index', tsrex.root):
+            n.item = index_map.get(n.item, n.item)
+
+        return tsrex | IndexPropagator()
+
+
+class TsrEx(_BaseEx, ArithmeticMixin, IndexRenamingMixin):
     pass
 
 

--- a/funfact/lang/interpreter/__init__.py
+++ b/funfact/lang/interpreter/__init__.py
@@ -10,7 +10,7 @@ from ._latex import LatexRenderer
 
 
 __all__ = [
-    'dfs_filter',
+    'dfs', 'dfs_filter',
     'ASCIIRenderer', 'Evaluator', 'EinsteinSpecGenerator',  'IndexPropagator',
     'LeafInitializer', 'LatexRenderer', 'PayloadMerger'
 ]

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -194,9 +194,22 @@ class PayloadMerger:
         return type(tsrex_list[0])(self(*[tsrex.root for tsrex in tsrex_list]))
 
 
+def dfs(node: _ASNode):
+    '''Returns an iterator that loop over all nodes in an AST in a depth-first
+    manner.'''
+
+    for child in flatten_if(
+        node.fields_fixed.values(),
+        lambda elem: isinstance(elem, (list, tuple))
+    ):
+        if isinstance(child, _ASNode):
+            yield from dfs(child)
+        yield node
+
+
 def dfs_filter(function: Callable[[_ASNode], bool], node: _ASNode):
     '''Returns an iterator that loop over all nodes in an AST in a depth-first
-    manner for which `function` evaluates to trues.'''
+    manner for which `function` evaluates to true.'''
 
     for child in flatten_if(
         node.fields_fixed.values(),

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -6,7 +6,7 @@ from typing import Optional
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._tensor import AbstractIndex, AbstractTensor
-from funfact.util.set import ordered_union, ordered_setminus
+from funfact.util.set import ordered_intersect, ordered_union, ordered_setminus
 
 
 class IndexPropagator(TranscribeInterpreter):
@@ -86,7 +86,12 @@ class IndexPropagator(TranscribeInterpreter):
                 ordered_union(l_outer, r_outer)
             )
             implied_out = l_outer + elementwise + r_outer
-            return implied_out, []
+            return implied_out, ordered_setminus(
+                keep_indices, ordered_intersect(
+                    lhs.live_indices,
+                    rhs.live_indices
+                )
+            )
         else:
             explicit_out = outidx.live_indices
             for i in keep_indices:


### PR DESCRIPTION
Allows the indices associated with the surviving dimensions to be replaced by new indices.
This is a necessary mechanism to implement #15.

```python
u = ff.tensor(2, 3)
v = ff.tensor(3, 5)
w = ff.tensor(5, 8)
X = ff.tensor(2, 8)
i, j, k, l = ff.indices(4)
a, b, c = ff.indices('a, b, c')
```

```
u[i, j] * v[j, ~k]
```
![image](https://user-images.githubusercontent.com/6081524/141704331-6b7c09be-7918-46e8-ae25-3aeb440d0fea.png)

```
(u[i, j] * v[j, ~k])[a, b]
```
![image](https://user-images.githubusercontent.com/6081524/141673451-d2e6a6b5-76be-4ab6-8756-fec0da208cc1.png)

```
(u[i, j] * v[~j, k])[a, b, c]
```
![image](https://user-images.githubusercontent.com/6081524/141673465-2992a0b0-710b-4d51-af6b-c7426a92bad7.png)
