### PR TITLE
Use the `[[*i, ...]]` syntax to denote Kronecker product indices.

### DIFF
--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -43,8 +43,10 @@ class Primitives:
         '''an abstract tensor'''
 
     @primitive(precedence=0)
-    def index(item: AbstractIndex, bound: bool):
-        '''an index; bound indices are not reduced even if appear twice'''
+    def index(item: AbstractIndex, bound: bool, kron: bool):
+        '''an index; bound indices are not reduced even if they appear twice;
+        kron indices lead to kronecker product between the dimensions with the
+        same index.'''
 
     @primitive(precedence=0)
     def indices(items: Tuple[AbstractIndex]):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -172,7 +172,12 @@ class TsrEx(_BaseEx, ArithmeticMixin, IndexRenamingMixin):
 
 class IndexEx(_BaseEx):
     def __invert__(self):
-        return IndexEx(dataclasses.replace(self.root, bound=True))
+        '''Implements the `~i` syntax.'''
+        return IndexEx(dataclasses.replace(self.root, bound=True, kron=False))
+
+    def __iter__(self):
+        '''Implements the `*i` syntax.'''
+        yield IndexEx(dataclasses.replace(self.root, bound=False, kron=True))
 
 
 class TensorEx(_BaseEx):
@@ -196,7 +201,7 @@ class EinopEx(TsrEx):
 
 
 def index(symbol=None):
-    return IndexEx(P.index(AbstractIndex(symbol), bound=False))
+    return IndexEx(P.index(AbstractIndex(symbol), bound=False, kron=False))
 
 
 def indices(spec):

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -17,9 +17,11 @@ class ASCIIRenderer(TranscribeInterpreter):
         return str(abstract.symbol)
 
     @as_payload
-    def index(self, item, bound, **kwargs):
+    def index(self, item, bound, kron, **kwargs):
         if bound:
             return f'~{str(item.symbol)}'
+        elif kron:
+            return f'*{str(item.symbol)}'
         else:
             return str(item.symbol)
 

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -52,7 +52,8 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
-    def index(self, item: AbstractIndex, bound: bool, **payload: Any):
+    def index(self, item: AbstractIndex, bound: bool, kron: bool,
+              **payload: Any):
         pass
 
     @abstractmethod
@@ -125,7 +126,8 @@ class TranscribeInterpreter(ABC):
         pass
 
     @abstractmethod
-    def index(self, item: AbstractIndex, bound: bool, **payload: Any):
+    def index(self, item: AbstractIndex, bound: bool, kron: bool,
+              **payload: Any):
         pass
 
     @abstractmethod

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -21,7 +21,7 @@ class Evaluator(ROOFInterpreter):
     def tensor(self, abstract, data, **kwargs):
         return data
 
-    def index(self, item, bound, **kwargs):
+    def index(self, item, bound, kron, **kwargs):
         return None
 
     def indices(self, items, **kwargs):

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -28,7 +28,7 @@ class IndexPropagator(TranscribeInterpreter):
         return [], []
 
     @as_payload
-    def index(self, item: AbstractIndex, bound: bool, **kwargs):
+    def index(self, item: AbstractIndex, bound: bool, kron: bool, **kwargs):
         return [item], [item] if bound else []
 
     @as_payload

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -40,7 +40,7 @@ class LeafInitializer(TranscribeInterpreter):
         return init_val
 
     @as_payload
-    def index(self, item, bound, **kwargs):
+    def index(self, item, bound, kron, **kwargs):
         return None
 
     @as_payload

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -33,8 +33,13 @@ class LatexRenderer(ROOFInterpreter):
     def tensor(self, abstract, **kwargs):
         return abstract._repr_tex_()
 
-    def index(self, item, bound, **kwargs):
-        accent = r'\widetilde' if bound else None
+    def index(self, item, bound, kron, **kwargs):
+        if bound:
+            accent = r'\widetilde'
+        elif kron:
+            accent = r'\overset{\otimes}'
+        else:
+            accent = None
         return fr'{{{item._repr_tex_(accent=accent)}}}'
 
     def indices(self, items, **kwargs):

--- a/funfact/lang/interpreter/_slicing_propagation.py
+++ b/funfact/lang/interpreter/_slicing_propagation.py
@@ -21,7 +21,8 @@ class SlicingPropagator():
     def tensor(self, abstract: AbstractTensor, slices, **kwargs):
         abstract.slices = None
 
-    def index(self, item: AbstractIndex, bound: bool, slices, **kwargs):
+    def index(self, item: AbstractIndex, bound: bool, kron: bool, slices,
+              **kwargs):
         item.slices = None
 
     def indices(self, items: AbstractIndex, slices, **kwargs):

--- a/funfact/lang/interpreter/_syntax_validation.py
+++ b/funfact/lang/interpreter/_syntax_validation.py
@@ -25,7 +25,7 @@ class SyntaxValidator:
                     f'its concrete-tensor initializer of {ini.shape}.'
                 )
 
-    def index(self, node: _ASNode, bound: bool, parent: _ASNode):
+    def index(self, node: _ASNode, bound: bool, kron: bool, parent: _ASNode):
         pass
 
     def indices(self, node: _ASNode, parent: _ASNode):

--- a/funfact/lang/interpreter/_syntax_validation.py
+++ b/funfact/lang/interpreter/_syntax_validation.py
@@ -25,8 +25,13 @@ class SyntaxValidator:
                     f'its concrete-tensor initializer of {ini.shape}.'
                 )
 
-    def index(self, node: _ASNode, bound: bool, kron: bool, parent: _ASNode):
-        pass
+    def index(self, node: _ASNode, parent: _ASNode):
+        i = node.item
+        if i.bound and i.kron:
+            raise SyntaxError(
+                f'Index {i} should not simultaneous imply elementwise and '
+                f'Kronecker product operations.'
+            )
 
     def indices(self, node: _ASNode, parent: _ASNode):
         for i in node.items:


### PR DESCRIPTION
Note: this is only the 'front end' of the Kronecker product syntax. Changed are needed in the evaluator/einop back end to carry out the calculations.

If the same index shows up between a pair of contracting tensors **and** at least one of the occurrences is decorated with the unary index multiplication sign `*`, the a Kronecker-style outer op operation will happen along the associated dimensions.

Example (note the double bracket `[[]]`, which is required in this case since we are _abusing_ the iterable unpacking operator here):
```
A = ff.tensor('A', 4, 4)
B = ff.tensor('B', 3, 4)
i, j = ff.indices('i, j')
A[[*i, j]] * B[i, ~j]
```
Leads to:
```
 sum:mul 
 ├── A[*i,j] 
 │   ├── A 
 │   ╰── *i,j 
 │       ├── *i 
 │       ╰── j 
 ╰── B[i,~j] 
     ├── B 
     ╰── i,~j 
         ├── i 
         ╰── ~j 
```
and
![image](https://user-images.githubusercontent.com/6081524/142756536-f592a0a3-5e3d-4ec0-9b7f-92d269f831cf.png)

This should yield a 12-by-4 matrix, where Kronecker product occurs along the first dimension, and elementwise product occurs along the second dimension.
