### PR TITLE
Transposition for all tensor expressions.

### DIFF
--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -76,7 +76,7 @@ class Primitives:
         '''pairwise einsum-like operations between tensors'''
 
     @primitive(precedence=9)
-    def tran(src: _ASNode, idst: _ASNode):
+    def tran(src: _ASNode, indices: _ASNode):
         '''transposition/axis reordering'''
 
     @classmethod

--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -76,7 +76,7 @@ class Primitives:
         '''pairwise einsum-like operations between tensors'''
 
     @primitive(precedence=9)
-    def tran(src: _ASNode, dst_indices: _ASNode):
+    def tran(src: _ASNode, idst: _ASNode):
         '''transposition/axis reordering'''
 
     @classmethod

--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -75,6 +75,10 @@ class Primitives:
     ):
         '''pairwise einsum-like operations between tensors'''
 
+    @primitive(precedence=9)
+    def tran(src: _ASNode, dst_indices: _ASNode):
+        '''transposition/axis reordering'''
+
     @classmethod
     def as_primitive(cls, raw):
         if isinstance(raw, _ASNode):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -166,7 +166,22 @@ class IndexRenamingMixin:
         return tsrex | IndexPropagator()
 
 
-class TsrEx(_BaseEx, ArithmeticMixin, IndexRenamingMixin):
+class TranspositionMixin:
+    '''transpose the axes by permuting the live indices into target indices.'''
+    @property
+    def T(self):
+        return self._T(self.root)
+
+    class _T(_BaseEx):
+        def __getitem__(self, indices):
+            return TsrEx(
+                P.tran(self.root,
+                       P.indices(tuple([i.root for i in as_tuple(indices)])))
+            )
+
+
+class TsrEx(_BaseEx, ArithmeticMixin, IndexRenamingMixin, TranspositionMixin):
+    '''A general tensor expression'''
     pass
 
 

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -51,5 +51,5 @@ class ASCIIRenderer(TranscribeInterpreter):
         return f'{reduction}:{pairwise}' + suffix
 
     @as_payload
-    def tran(self, src, dst_indices, **kwargs):
-        return f'^T[{dst_indices.ascii}]'
+    def tran(self, src, idst, **kwargs):
+        return f'^T[{idst.ascii}]'

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -51,5 +51,5 @@ class ASCIIRenderer(TranscribeInterpreter):
         return f'{reduction}:{pairwise}' + suffix
 
     @as_payload
-    def tran(self, src, idst, **kwargs):
-        return f'^T[{idst.ascii}]'
+    def tran(self, src, indices, **kwargs):
+        return f'^T[{indices.ascii}]'

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -49,3 +49,7 @@ class ASCIIRenderer(TranscribeInterpreter):
     def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, **kwargs):
         suffix = f' -> {outidx.ascii}' if outidx is not None else ''
         return f'{reduction}:{pairwise}' + suffix
+
+    @as_payload
+    def tran(self, src, dst_indices, **kwargs):
+        return f'^T[{dst_indices.ascii}]'

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -83,6 +83,10 @@ class ROOFInterpreter(ABC):
             pairwise: str, outidx: Any, **payload: Any):
         pass
 
+    @abstractmethod
+    def tran(self, src: Any, dst_indices: Iterable[Any]):
+        pass
+
     def __call__(self, node: _ASNode, parent: _ASNode = None):
         fields_fixed = {
             name: _deep_apply(self, value, node)
@@ -155,6 +159,10 @@ class TranscribeInterpreter(ABC):
     @abstractmethod
     def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
             pairwise: str, outidx: Optional[P.indices], **payload: Any):
+        pass
+
+    @abstractmethod
+    def tran(self, src: Numeric, dst_indices: P.indices):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -84,7 +84,7 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
-    def tran(self, src: Any, dst_indices: Iterable[Any]):
+    def tran(self, src: Any, idst: Iterable[Any]):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):
@@ -162,7 +162,7 @@ class TranscribeInterpreter(ABC):
         pass
 
     @abstractmethod
-    def tran(self, src: Numeric, dst_indices: P.indices):
+    def tran(self, src: Numeric, idst: P.indices):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -84,7 +84,7 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
-    def tran(self, src: Any, idst: Iterable[Any]):
+    def tran(self, src: Any, indices: Iterable[Any]):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):
@@ -162,7 +162,7 @@ class TranscribeInterpreter(ABC):
         pass
 
     @abstractmethod
-    def tran(self, src: Numeric, idst: P.indices):
+    def tran(self, src: Numeric, indices: P.indices):
         pass
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -75,6 +75,6 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
                f'->{map(live_indices)}'
 
     @as_payload
-    def tran(self, src: Numeric, idst: P.indices, live_indices, **kwargs):
+    def tran(self, src: Numeric, indices: P.indices, live_indices, **kwargs):
         map = IndexMap()
         return f'{map(src.live_indices)}->{map(live_indices)}'

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -73,3 +73,8 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
         map = IndexMap()
         return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
                f'->{map(live_indices)}'
+
+    @as_payload
+    def tran(self, src: Numeric, dst_indices: P.indices, live_indices, **kwargs):
+        map = IndexMap()
+        return f'{map(src.live_indices)}->{map(live_indices)}'

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -75,6 +75,6 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
                f'->{map(live_indices)}'
 
     @as_payload
-    def tran(self, src: Numeric, dst_indices: P.indices, live_indices, **kwargs):
+    def tran(self, src: Numeric, idst: P.indices, live_indices, **kwargs):
         map = IndexMap()
         return f'{map(src.live_indices)}->{map(live_indices)}'

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -43,6 +43,6 @@ class Evaluator(ROOFInterpreter):
             **kwargs):
         return self._binary_operator(reduction, pairwise, lhs, rhs, einspec)
 
-    def tran(self, src, idst, einspec, **kwargs):
+    def tran(self, src, indices, einspec, **kwargs):
         in_spec, out_spec = einspec.split('->')
         return np.transpose(src, [in_spec.index(i) for i in out_spec])

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -43,6 +43,6 @@ class Evaluator(ROOFInterpreter):
             **kwargs):
         return self._binary_operator(reduction, pairwise, lhs, rhs, einspec)
 
-    def tran(self, src, dst_indices, einspec, **kwargs):
+    def tran(self, src, idst, einspec, **kwargs):
         in_spec, out_spec = einspec.split('->')
         return np.transpose(src, [in_spec.index(i) for i in out_spec])

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -42,3 +42,7 @@ class Evaluator(ROOFInterpreter):
     def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, einspec,
             **kwargs):
         return self._binary_operator(reduction, pairwise, lhs, rhs, einspec)
+
+    def tran(self, src, dst_indices, einspec, **kwargs):
+        in_spec, out_spec = einspec.split('->')
+        return np.transpose(src, [in_spec.index(i) for i in out_spec])

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -103,5 +103,5 @@ class IndexPropagator(TranscribeInterpreter):
             return explicit_survival, []
 
     @as_payload
-    def tran(self, src: Numeric, idst: P.indices, **kwargs):
-        return idst.live_indices, idst.keep_indices
+    def tran(self, src: Numeric, indices: P.indices, **kwargs):
+        return indices.live_indices, indices.keep_indices

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -101,3 +101,7 @@ class IndexPropagator(TranscribeInterpreter):
                         f'existing in the operand indices list {live}.'
                     )
             return explicit_survival, []
+
+    @as_payload
+    def tran(self, src: Numeric, dst_indices: P.indices, **kwargs):
+        return dst_indices.live_indices, dst_indices.keep_indices

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -103,5 +103,5 @@ class IndexPropagator(TranscribeInterpreter):
             return explicit_survival, []
 
     @as_payload
-    def tran(self, src: Numeric, dst_indices: P.indices, **kwargs):
-        return dst_indices.live_indices, dst_indices.keep_indices
+    def tran(self, src: Numeric, idst: P.indices, **kwargs):
+        return idst.live_indices, idst.keep_indices

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -68,5 +68,5 @@ class LeafInitializer(TranscribeInterpreter):
         return None
 
     @as_payload
-    def tran(self, src, dst_indices, **kwargs):
+    def tran(self, src, idst, **kwargs):
         return None

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -66,3 +66,7 @@ class LeafInitializer(TranscribeInterpreter):
     @as_payload
     def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, **kwargs):
         return None
+
+    @as_payload
+    def tran(self, src, dst_indices, **kwargs):
+        return None

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -68,5 +68,5 @@ class LeafInitializer(TranscribeInterpreter):
         return None
 
     @as_payload
-    def tran(self, src, idst, **kwargs):
+    def tran(self, src, indices, **kwargs):
         return None

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -68,5 +68,5 @@ class LatexRenderer(ROOFInterpreter):
         suffix = fr'\rightarrow_{{{outidx}}}' if outidx is not None else ''
         return body + suffix
 
-    def tran(self, src, dst_indices, **kwargs):
-        return fr'{{{src}}}^{{\mathsf{{T}}: {dst_indices}}}'
+    def tran(self, src, idst, **kwargs):
+        return fr'{{{src}}}^{{\mathsf{{T}}: {idst}}}'

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -68,5 +68,5 @@ class LatexRenderer(ROOFInterpreter):
         suffix = fr'\rightarrow_{{{outidx}}}' if outidx is not None else ''
         return body + suffix
 
-    def tran(self, src, idst, **kwargs):
-        return fr'{{{src}}}^{{\mathsf{{T}}: {idst}}}'
+    def tran(self, src, indices, **kwargs):
+        return fr'{{{src}}}^{{\mathsf{{T}}: {indices}}}'

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -67,3 +67,6 @@ class LatexRenderer(ROOFInterpreter):
         body = fr'{lhs} {op} {rhs}'
         suffix = fr'\rightarrow_{{{outidx}}}' if outidx is not None else ''
         return body + suffix
+
+    def tran(self, src, dst_indices, **kwargs):
+        return fr'{{{src}}}^{{\mathsf{{T}}: {dst_indices}}}'

--- a/funfact/lang/interpreter/_slicing_propagation.py
+++ b/funfact/lang/interpreter/_slicing_propagation.py
@@ -64,6 +64,9 @@ class SlicingPropagator():
         lhs.slices = lhs_slices
         rhs.slices = rhs_slices
 
+    def tran(self, src: Numeric, dst_indices: P.indices, slices, **kwargs):
+        src.slices = [slices[src.live_indices.index(i)] for i in dst_indices.live_indices]
+
     def __call__(self, node: _ASNode, parent: _ASNode = None):
         node = copy.copy(node)
         rule = getattr(self, node.name)

--- a/funfact/lang/interpreter/_slicing_propagation.py
+++ b/funfact/lang/interpreter/_slicing_propagation.py
@@ -64,8 +64,10 @@ class SlicingPropagator():
         lhs.slices = lhs_slices
         rhs.slices = rhs_slices
 
-    def tran(self, src: Numeric, dst_indices: P.indices, slices, **kwargs):
-        src.slices = [slices[src.live_indices.index(i)] for i in dst_indices.live_indices]
+    def tran(self, src: Numeric, idst: P.indices, slices, **kwargs):
+        src.slices = [
+            slices[src.live_indices.index(i)] for i in idst.live_indices
+        ]
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):
         node = copy.copy(node)

--- a/funfact/lang/interpreter/_slicing_propagation.py
+++ b/funfact/lang/interpreter/_slicing_propagation.py
@@ -64,9 +64,9 @@ class SlicingPropagator():
         lhs.slices = lhs_slices
         rhs.slices = rhs_slices
 
-    def tran(self, src: Numeric, idst: P.indices, slices, **kwargs):
+    def tran(self, src: Numeric, indices: P.indices, slices, **kwargs):
         src.slices = [
-            slices[src.live_indices.index(i)] for i in idst.live_indices
+            slices[src.live_indices.index(i)] for i in indices.live_indices
         ]
 
     def __call__(self, node: _ASNode, parent: _ASNode = None):

--- a/funfact/lang/test_tsrex.py
+++ b/funfact/lang/test_tsrex.py
@@ -32,5 +32,6 @@ def test_transposition():
     i, j, k, r = indices('i, j, k, l')
     for perm in it.permutations([i, j, k, r]):
         AT = A[i, j, k, r].T[[*perm]]
+        assert AT.root.name == 'tran'
         # TODO: More tests once
         # [#32](https://github.com/yhtang/FunFact/issues/32) is taken care of.

--- a/funfact/lang/test_tsrex.py
+++ b/funfact/lang/test_tsrex.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+import itertools as it
+import numpy as np
+from ._tsrex import index, indices, tensor
+
+
+def test_abstract_tensor():
+    u = tensor(np.ones(3))
+    v = tensor('v', np.eye(4))
+    w = tensor(4, 2, 5)
+    x = tensor('x', 9, 2)
+    for t in [u, v, w, x]:
+        assert t.root.name == 'tensor'
+        assert hasattr(t.root.abstract, 'symbol')
+    # TODO: rewrite once [#31](https://github.com/yhtang/FunFact/issues/31)
+    # is addressed.
+    assert u.root.abstract.ndim == 1
+    assert v.root.abstract.ndim == 2
+    assert w.root.abstract.ndim == 3
+    assert x.root.abstract.ndim == 2
+    assert u.root.abstract.shape == (3,)
+    assert v.root.abstract.shape == (4, 4)
+    assert w.root.abstract.shape == (4, 2, 5)
+    assert x.root.abstract.shape == (9, 2)
+
+
+def test_transposition():
+
+    A = tensor('A', 2, 3, 4, 5)
+    i, j, k, r = indices('i, j, k, l')
+    for perm in it.permutations([i, j, k, r]):
+        AT = A[i, j, k, r].T[[*perm]]
+        # TODO: More tests once
+        # [#32](https://github.com/yhtang/FunFact/issues/32) is taken care of.


### PR DESCRIPTION
Every tensor expression now has the `.T` property, which when indexed indicate the transposition to be applied to the source tensor.

Example:
```python
A = ff.tensor('A', 2, 3)
fac = Factorization(A[i, j].T[j, i])
print(fac())
print(fac['A'])  # fac() is the transposition o f A
```
and
```python
A = ff.tensor('A', 2, 3, 4)
fac = Factorization(A[i, j, k].T[k, i, j])
print(fac())
print(fac['A'])  # reorder dimensions of A
```

## A note on the difference between the `.T[...]`, `[...]`, and `>> (...)` syntax
All three syntaxes concerns the manipulation of indices of the tensor expression output. However:
- The `>>` syntax is only applied to a binary operation and is used to facilitate surviving index inference. It specifies which indices from the lhs/src tensors should be preserved.
- The direct `[..]` is only meant to **rename** the remaining dimensions of a (potentially complex) tensor expression to help compositing further contractions. It does not modify the underlying data. For example, `A[i, j]` and `A[a, b]` alone does not make a difference --- the actual computation depends on what indices the other operand carries and also what are explicitly dictated by the `>>` syntax.
- The `.T[...]` syntax directly expresses transposition. In fact, it is most conveniently **used in tandem** with `[...]`, such as:
  ```python
  tsrex = ...
  tsrex[i, j, k].T[k, i, j]
  ```
  as an intuitive way to specify the movement of the dimensions.

