### PR TITLE
Shape analyzer and exposing properties of tensor expressions

### DIFF
--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -82,8 +82,14 @@ class _BaseEx(_AST):
     _index_propagator = IndexPropagator()
     _shape_analyzer = ShapeAnalyzer()
 
+    def __init__(self, data=None):
+        super().__init__(data)
+        self.root = self._einspec_generator(self._shape_analyzer(
+                    self._index_propagator(self.root)))
+        self._latex = self._latex_intr(self.root)
+
     def _repr_html_(self):
-        return f'''$${self._latex_intr(self.root)}$$'''
+        return f'''$${self._latex}$$'''
 
     @property
     def asciitree(self):
@@ -91,12 +97,11 @@ class _BaseEx(_AST):
 
     @property
     def shape(self):
-        return (self | self._index_propagator |
-                self._shape_analyzer).root.shape
+        return self.root.shape
 
     @property
     def live_indices(self):
-        return (self | self._index_propagator).root.live_indices
+        return self.root.live_indices
 
     @property
     def ndim(self):
@@ -104,8 +109,7 @@ class _BaseEx(_AST):
 
     @property
     def einspec(self):
-        return (self | self._index_propagator |
-                self._einspec_generator).root.einspec
+        return self.root.einspec
 
 
 class ArithmeticMixin:

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -8,7 +8,8 @@ from funfact.util.iterable import as_namedtuple, as_tuple, flatten_if
 from funfact.util.typing import _is_tensor
 from ._ast import _AST, _ASNode, Primitives as P
 from .interpreter import (
-    dfs_filter, ASCIIRenderer, LatexRenderer, IndexPropagator
+    dfs_filter, ASCIIRenderer, LatexRenderer, IndexPropagator, ShapeAnalyzer,
+    EinsteinSpecGenerator
 )
 from ._terminal import AbstractIndex, AbstractTensor
 
@@ -77,6 +78,9 @@ class _BaseEx(_AST):
 
     _latex_intr = LatexRenderer()
     _asciitree_factory = ASCIITreeFactory()
+    _einspec_generator = EinsteinSpecGenerator()
+    _index_propagator = IndexPropagator()
+    _shape_analyzer = ShapeAnalyzer()
 
     def _repr_html_(self):
         return f'''$${self._latex_intr(self.root)}$$'''
@@ -84,6 +88,24 @@ class _BaseEx(_AST):
     @property
     def asciitree(self):
         return self._asciitree_factory(self.root)
+
+    @property
+    def shape(self):
+        return (self | self._index_propagator |
+                self._shape_analyzer).root.shape
+
+    @property
+    def live_indices(self):
+        return (self | self._index_propagator).root.live_indices
+
+    @property
+    def ndim(self):
+        return len(self.live_indices)
+
+    @property
+    def einspec(self):
+        return (self | self._index_propagator |
+                self._einspec_generator).root.einspec
 
 
 class ArithmeticMixin:

--- a/funfact/lang/interpreter/__init__.py
+++ b/funfact/lang/interpreter/__init__.py
@@ -9,11 +9,11 @@ from ._initialization import LeafInitializer
 from ._latex import LatexRenderer
 from ._elementwise import ElementwiseEvaluator
 from ._slicing_propagation import SlicingPropagator
-
+from ._shape import ShapeAnalyzer
 
 __all__ = [
     'dfs', 'dfs_filter',
     'ASCIIRenderer', 'Evaluator', 'EinsteinSpecGenerator',  'IndexPropagator',
     'LeafInitializer', 'LatexRenderer', 'PayloadMerger',
-    'ElementwiseEvaluator', 'SlicingPropagator'
+    'ElementwiseEvaluator', 'SlicingPropagator', 'ShapeAnalyzer'
 ]

--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from typing import Optional, Tuple
+from ._base import TranscribeInterpreter
+from funfact.lang._ast import Primitives as P
+from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+
+
+class ShapeAnalyzer(TranscribeInterpreter):
+    '''The shape analyzer checks the shapes of the nodes in the AST.'''
+    Tensorial = TranscribeInterpreter.Tensorial
+    Numeric = TranscribeInterpreter.Numeric
+
+    as_payload = TranscribeInterpreter.as_payload('shape')
+
+    @as_payload
+    def literal(self, value: LiteralValue, **kwargs):
+        return None
+
+    @as_payload
+    def tensor(self, abstract: AbstractTensor, **kwargs):
+        return abstract.shape
+
+    @as_payload
+    def index(self, item: AbstractIndex, bound: bool, **kwargs):
+        return None
+
+    @as_payload
+    def indices(self, items: Tuple[P.index], **kwargs):
+        return None
+
+    @as_payload
+    def index_notation(self, tensor: P.tensor, indices: P.indices,  **kwargs):
+        return None
+
+    @as_payload
+    def call(self, f: str, x: Tensorial, **kwargs):
+        return None
+
+    @as_payload
+    def pow(self, base: Numeric, exponent: Numeric, **kwargs):
+        return None
+
+    @as_payload
+    def neg(self, x: Numeric, **kwargs):
+        return None
+
+    @as_payload
+    def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
+            pairwise: str, outidx: Optional[P.indices], live_indices,
+            **kwargs):
+        return None

--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -72,8 +72,5 @@ class ShapeAnalyzer(TranscribeInterpreter):
 
     @as_payload
     def tran(self, src: Numeric, live_indices, **kwargs):
-        dict_src = dict(zip(src.live_indices, src.shape))
-        shape = []
-        for i in live_indices:
-            shape.append(dict_src[i])
-        return tuple(shape)
+        return tuple(src.shape[src.live_indices.index(i)]
+                     for i in live_indices)

--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -31,22 +31,49 @@ class ShapeAnalyzer(TranscribeInterpreter):
 
     @as_payload
     def index_notation(self, tensor: P.tensor, indices: P.indices,  **kwargs):
-        return None
+        return tensor.shape
 
     @as_payload
     def call(self, f: str, x: Tensorial, **kwargs):
-        return None
+        return x.shape
 
     @as_payload
     def pow(self, base: Numeric, exponent: Numeric, **kwargs):
-        return None
+        if base.shape:
+            return base.shape
+        else:
+            return exponent.shape
 
     @as_payload
     def neg(self, x: Numeric, **kwargs):
-        return None
+        return x.shape
 
     @as_payload
     def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
             pairwise: str, outidx: Optional[P.indices], live_indices,
             **kwargs):
-        return None
+        dict_lhs = dict(zip(lhs.live_indices, lhs.shape))
+        dict_rhs = dict(zip(rhs.live_indices, rhs.shape))
+        shape = []
+        for i in live_indices:
+            if i in lhs.live_indices and i in rhs.live_indices:
+                if dict_lhs[i] != dict_rhs[i]:
+                    raise SyntaxError(
+                        f'Dimension of contracting index on left-hand side '
+                        f'({dict_lhs[i]}) does not match dimension of '
+                        f'right-hand side ({dict_lhs[i]}).'
+                    )
+                shape.append(dict_lhs[i])
+            elif i in lhs.live_indices:
+                shape.append(dict_lhs[i])
+            else:
+                shape.append(dict_rhs[i])
+        return tuple(shape)
+
+    @as_payload
+    def tran(self, src: Numeric, live_indices, **kwargs):
+        dict_src = dict(zip(src.live_indices, src.shape))
+        shape = []
+        for i in live_indices:
+            shape.append(dict_src[i])
+        return tuple(shape)

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -8,7 +8,8 @@ from funfact.lang.interpreter import (
     PayloadMerger,
     IndexPropagator,
     ElementwiseEvaluator,
-    SlicingPropagator
+    SlicingPropagator,
+    ShapeAnalyzer
 )
 from jax.tree_util import register_pytree_node_class
 
@@ -29,18 +30,24 @@ class Factorization:
     _payload_merger = PayloadMerger()
     _index_propagator = IndexPropagator()
     _einspec_generator = EinsteinSpecGenerator()
+    _shape_analyzer = ShapeAnalyzer()
     _evaluator = Evaluator()
     _elementwise_evaluator = ElementwiseEvaluator()
 
     def __init__(self, tsrex, initialize=True):
         self._tsrex = (
             (tsrex | self._leaf_initializer) if initialize is True else tsrex,
-            (tsrex | self._index_propagator | self._einspec_generator)
+            (tsrex | self._index_propagator | self._einspec_generator |
+             self._shape_analyzer)
         ) | self._payload_merger
 
     @property
     def tsrex(self):
         return self._tsrex
+
+    @property
+    def shape(self):
+        return self._tsrex.root.shape
 
     def __call__(self):
         '''Shorthand for :py:meth:`forward`.'''


### PR DESCRIPTION
Closes #31.

Example usage:
```
A = ff.tensor('A', 2, 3, 4)
B = ff.tensor('B', 4, 3, 5)
i, j, k, l = ff.indices('i, j, k, l')
tsrex = A[i, j, k] * B[k, ~j, l]
f = Factorization(tsrex)
print(f.shape)
print(tsrex.shape)
print(tsrex.ndim)
print(tsrex.live_indices)
print(tsrex.einspec)
```