### PR TITLE
Caching for tensor expression properties

### DIFF
--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -36,10 +36,13 @@ class Factorization:
     _elementwise_evaluator = ElementwiseEvaluator()
 
     def __init__(self, tsrex, initialize=True, nvec=1):
+        tsrex = tsrex | self._index_propagator
         if nvec > 1:
             tsrex = tsrex | Vectorizer(nvec)
+            tsrex = tsrex | self._index_propagator
         if initialize is True:
             tsrex = tsrex | self._leaf_initializer
+        tsrex = tsrex | self._shape_analyzer | self._einspec_generator
         self._tsrex = tsrex
 
     @property


### PR DESCRIPTION
Solves #43 

Removed `__init__` from `_BaseEx` and replaced with `lru_cache` decorator.

Code snippet to test timings of repeatedly getting a cached property:
```
import funfact as ff
T = ff.tensor('T', 3, 3, 3)
u1 = ff.tensor('u_1', 10, 3)
u2 = ff.tensor('u_2', 20, 3)
u3 = ff.tensor('u_3', 30, 3)
i1, i2, i3, k1, k2, k3 = ff.indices('i_1, i_2, i_3, k_1, k_2, k_3')
tsrex = T[k1, k2, k3] * u1[i1, k1] * u2[i2, k2] * u3[i3, k3]


from functools import wraps
from time import time

def timing(f):
    @wraps(f)
    def wrap(*args, **kw):
        ts = time()
        result = f(*args, **kw)
        te = time()
        print('func:%r args:[%r, %r] took: %2.4f sec' %
          (f.__name__, args, kw, te-ts))
        return result
    return wrap

@timing
def time_attribute(tsrex, prop):
    return getattr(tsrex, prop)

time_attribute(tsrex,'shape')
time_attribute(tsrex,'shape')
time_attribute(tsrex,'einspec')
time_attribute(tsrex,'einspec')
time_attribute(tsrex,'live_indices')
time_attribute(tsrex,'live_indices')
time_attribute(tsrex,'ndim')
time_attribute(tsrex,'ndim')
```