### PR TITLE
Use stricter criterion to avoid confusing true iterables with `*i`.

### DIFF
--- a/funfact/util/iterable.py
+++ b/funfact/util/iterable.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from collections import namedtuple
-from typing import Iterable
+from typing import List, Tuple
 
 
 def flatten(iterable):
@@ -94,7 +94,7 @@ def as_namedtuple(title, **kwargs):
 
 
 def as_tuple(elements):
-    if isinstance(elements, Iterable):
+    if isinstance(elements, (List, Tuple)):
         return tuple(elements)
     else:
         return (elements,)


### PR DESCRIPTION
Fixes #47.

Only unpacks the incoming key if it is explicitly a `List` or `Tuple`, and do not unpack merely because it has an `__iter__` method.