### PR TITLE
Kronecker backend

### DIFF
--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -48,12 +48,11 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
     pairwise: str
         Name of the pairwise operator
     '''
-
     # parse input spec string
-    lhs_spec, rhs_spec, res_spec, kron_spec = re.split(r'\W+', spec)
+    lhs_spec, rhs_spec, out_spec, kron_spec = re.split(r'\W+', spec)
     lhs_spec = list(lhs_spec)
     rhs_spec = list(rhs_spec)
-    res_spec = list(res_spec)
+    out_spec = list(out_spec)
     kron_spec = list(kron_spec)
 
     # reorder lhs and rhs in alphabetical order
@@ -67,51 +66,66 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
     indices_all = sorted(list(indices_all))
 
     # determine dimensions of lhs and rhs tensors,
-    # contraction axis, and remaining indices
+    # contraction axis, Kronecker indices and remaining indices
+    shape_lhs = lhs.shape
+    shape_rhs = rhs.shape
+    j_l = 0
+    j_r = 0
+    i = 0
     dim_lhs = []
     dim_rhs = []
     con_ax = []
     indices_rem = []
-    for i, c in enumerate(indices_all):
-        if c in lhs_spec:
-            dim_lhs.append(slice(None))
-        else:
-            dim_lhs.append(None)
-        if c in rhs_spec:
-            dim_rhs.append(slice(None))
-        else:
-            dim_rhs.append(None)
-        if c not in res_spec:
-            con_ax.append(i)
-        else:
+    kron_res = []
+    for c in indices_all:
+        if c in out_spec:
+            # non-contracting index
             indices_rem.append(c)
-
-    # broadcast dimensions
-    lhs = lhs[tuple(dim_lhs)]
-    rhs = rhs[tuple(dim_rhs)]
-
-    # blow up kron indices
-    shape_lhs = lhs.shape
-    shape_rhs = rhs.shape
-    tile_lhs = []
-    tile_rhs = []
-    for i, c in enumerate(indices_all):
-        if c in kron_spec:
-            tile_lhs.append(shape_rhs[i])
-            tile_rhs.append(shape_lhs[i])
+            if c in kron_spec:
+                dim_lhs.append(None)
+                dim_lhs.append(slice(None))
+                dim_rhs.append(slice(None))
+                dim_rhs.append(None)
+                kron_res.append(shape_lhs[j_l]*shape_rhs[j_r])
+                i += 2
+                j_l += 1
+                j_r += 1
+            else:
+                if c in lhs_spec and c in rhs_spec:
+                    dim_lhs.append(slice(None))
+                    dim_rhs.append(slice(None))
+                    kron_res.append(shape_lhs[j_l])
+                    j_l += 1
+                    j_r += 1
+                elif c in lhs_spec:
+                    dim_lhs.append(slice(None))
+                    dim_rhs.append(None)
+                    kron_res.append(shape_lhs[j_l])
+                    j_l += 1
+                elif c in rhs_spec:
+                    dim_lhs.append(None)
+                    dim_rhs.append(slice(None))
+                    kron_res.append(shape_rhs[j_r])
+                    j_r += 1
+                i += 1
         else:
-            tile_lhs.append(1)
-            tile_rhs.append(1)
-    lhs = np.tile(lhs, tuple(tile_lhs))
-    rhs = np.tile(rhs, tuple(tile_rhs))
+            # contracting index
+            dim_lhs.append(slice(None))
+            dim_rhs.append(slice(None))
+            con_ax.append(i)
+            j_l += 1
+            j_r += 1
+            i += 1
 
     # compute the contraction in alphabetical order
     op_redu = getattr(DummyBackend, reduction)
     op_pair = getattr(DummyBackend, pairwise)
 
-    result = op_redu(op_pair(lhs, rhs), axis=tuple(con_ax))
+    result = np.reshape(op_redu(op_pair(lhs[tuple(dim_lhs)],
+                        rhs[tuple(dim_rhs)]), axis=tuple(con_ax)),
+                        tuple(kron_res),  order="F")
 
-    # reorder contraction according to res_spec
+    # reorder contraction according to out_spec
     dictionary = dict(zip(indices_rem, numpy.arange(len(indices_rem))))
-    res_order = [dictionary[key] for key in res_spec]
+    res_order = [dictionary[key] for key in out_spec]
     return np.transpose(result, res_order)

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -69,10 +69,10 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
     @as_payload
     def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
             pairwise: str, outidx: Optional[P.indices], live_indices,
-            **kwargs):
+            kron_indices, **kwargs):
         map = IndexMap()
         return f'{map(lhs.live_indices)},{map(rhs.live_indices)}'\
-               f'->{map(live_indices)}'
+               f'->{map(live_indices)}|{map(kron_indices)}'
 
     @as_payload
     def tran(self, src: Numeric, indices: P.indices, live_indices, **kwargs):

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -29,7 +29,7 @@ class IndexPropagator(TranscribeInterpreter):
 
     @as_payload
     def index(self, item: AbstractIndex, bound: bool, kron: bool, **kwargs):
-        return [item], [item] if bound else [], [item] if kron else []
+        return [item], [item] if bound or kron else [], [item] if kron else []
 
     @as_payload
     def indices(self, items: AbstractIndex, **kwargs):
@@ -85,10 +85,9 @@ class IndexPropagator(TranscribeInterpreter):
             free_r = ordered_setminus(rhs.live_indices, lhs.live_indices)
             free = ordered_union(free_l, free_r)
             repeated = ordered_intersect(lhs.live_indices, rhs.live_indices)
-            keep_bound = ordered_setminus(keep, free)
-            kron_bound = ordered_setminus(kron, free)
+            bound = ordered_setminus(keep, free)
             lone_keep = ordered_setminus(keep, repeated)
-            implied_survival = free_l + keep_bound + kron_bound + free_r
+            implied_survival = free_l + bound + free_r
             return implied_survival, lone_keep, kron
         else:
             explicit_survival = outidx.live_indices

--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -51,19 +51,22 @@ class ShapeAnalyzer(TranscribeInterpreter):
     @as_payload
     def ein(self, lhs: Numeric, rhs: Numeric, precedence: int, reduction: str,
             pairwise: str, outidx: Optional[P.indices], live_indices,
-            **kwargs):
+            kron_indices, **kwargs):
         dict_lhs = dict(zip(lhs.live_indices, lhs.shape))
         dict_rhs = dict(zip(rhs.live_indices, rhs.shape))
         shape = []
         for i in live_indices:
             if i in lhs.live_indices and i in rhs.live_indices:
-                if dict_lhs[i] != dict_rhs[i]:
-                    raise SyntaxError(
-                        f'Dimension of contracting index on left-hand side '
-                        f'({dict_lhs[i]}) does not match dimension of '
-                        f'right-hand side ({dict_lhs[i]}).'
-                    )
-                shape.append(dict_lhs[i])
+                if i in kron_indices:
+                    shape.append(dict_lhs[i]*dict_rhs[i])
+                else:
+                    if dict_lhs[i] != dict_rhs[i]:
+                        raise SyntaxError(
+                            f'Dimension of contracting index on left-hand side'
+                            f' ({dict_lhs[i]}) does not match dimension of '
+                            f'right-hand side ({dict_lhs[i]}).'
+                        )
+                    shape.append(dict_lhs[i])
             elif i in lhs.live_indices:
                 shape.append(dict_lhs[i])
             else:


### PR DESCRIPTION
Working on Kronecker backend #34. 

There are a few outstanding issues for this draft PR, but the basic functionality works.

**Issues:**
- `_einop` still uses a spec string for now, everything after the identifier `|` at the end of the spec string is considered a Kronecker index
- there is an issue with the `implied_survival` indices: the order between `keep_bound` and `keep_kron` is arbitrary and can be incorrect. See second test case below.
- the shape analyzer is not yet updated

The code snippet below tests the functionality:
```Python
import funfact as ff
from funfact.lang.interpreter import EinsteinSpecGenerator, IndexPropagator, Evaluator, LeafInitializer
_my_ein = EinsteinSpecGenerator()
_my_index = IndexPropagator()
_my_eval = Evaluator()
_my_init = LeafInitializer()
A = ff.tensor('A',2,3)
B = ff.tensor('B',3,3)
i, j, k = ff.indices('i, j, k')
#tsrex = A[[*i, *j]] * B[i,j] # Expect -> 6 x 9, get: 6 x 9 
tsrex = A[[*i, ~j]] * B[i,j] # Expect -> 6 x 3, get: 3 x 6 !!
#tsrex = A[[*i,  j]] * B[i,j] # Expect-> 6, get: 6 
#tsrex = A[[i,   j]] * B[j,k] # Expect -> 2 x 3, get: 2 x 3
#tsrex = A[[i,  ~j]] * B[j,k] # Expect -> 2 x 3 x 3, get: 2 x 3 x 3
#tsrex = A[[i,  *j]] * B[j,k] # Expect -> 2 x 9 x 3, get: 2 x 9 x 3
tsrex = tsrex | _my_index  | _my_init | _my_ein
out = tsrex | _my_eval
print(out.shape)
```