### PR TITLE
fixes shape analyzer bug #52

### DIFF
--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -54,18 +54,22 @@ class ShapeAnalyzer(TranscribeInterpreter):
             kron_indices, **kwargs):
         dict_lhs = dict(zip(lhs.live_indices, lhs.shape))
         dict_rhs = dict(zip(rhs.live_indices, rhs.shape))
+
+        for i in lhs.live_indices:
+            if i in rhs.live_indices and i not in kron_indices:
+                if dict_lhs[i] != dict_rhs[i]:
+                    raise SyntaxError(
+                        f'Dimension of elementwise index {i} on left-hand side'
+                        f' ({dict_lhs[i]}) does not match dimension of '
+                        f'right-hand side ({dict_rhs[i]}).'
+                    )
+
         shape = []
         for i in live_indices:
             if i in lhs.live_indices and i in rhs.live_indices:
                 if i in kron_indices:
                     shape.append(dict_lhs[i]*dict_rhs[i])
                 else:
-                    if dict_lhs[i] != dict_rhs[i]:
-                        raise SyntaxError(
-                            f'Dimension of contracting index on left-hand side'
-                            f' ({dict_lhs[i]}) does not match dimension of '
-                            f'right-hand side ({dict_lhs[i]}).'
-                        )
                     shape.append(dict_lhs[i])
             elif i in lhs.live_indices:
                 shape.append(dict_lhs[i])

--- a/funfact/lang/test_tsrex.py
+++ b/funfact/lang/test_tsrex.py
@@ -35,3 +35,19 @@ def test_transposition():
         assert AT.root.name == 'tran'
         # TODO: More tests once
         # [#32](https://github.com/yhtang/FunFact/issues/32) is taken care of.
+
+
+def test_shape():
+    A = tensor('A', 2, 3)
+    B = tensor('B', 3, 4)
+    i, j = indices('i, j')
+    tsrex = A[[i, j]] * B[[i, j]]
+    with pytest.raises(SyntaxError):
+        tsrex.shape
+    tsrex = A[[*i, j]] * B[[*i, j]]
+    with pytest.raises(SyntaxError):
+        tsrex.shape
+    tsrex = A[[*i, *j]] * B[[*i, *j]]
+    expected_shape = (6, 12)
+    for t, e in zip(tsrex.shape, expected_shape):
+        assert t == e


### PR DESCRIPTION
Closes #52. The shape analyzer now throws a `SyntaxError` on the example from the bug report. Simple test cases are added.