### PR TITLE
Added the complex conjugate math function. Closes #56.

### DIFF
--- a/funfact/lang/_math.py
+++ b/funfact/lang/_math.py
@@ -5,6 +5,7 @@ from ._ast import Primitives as _P
 
 
 def abs(x): return _T(_P.call('abs', _BaseEx(x).root))
+def conj(x): return _T(_P.call('conj', _BaseEx(x).root))
 def exp(x): return _T(_P.call('exp', _BaseEx(x).root))
 def log(x): return _T(_P.call('log', _BaseEx(x).root))
 def sin(x): return _T(_P.call('sin', _BaseEx(x).root))


### PR DESCRIPTION
Instead of implementing `conj` as a property of a tensor expression, I decided to make it a math function alongside others like `sin`, `cos`, etc. This is the minimal effort solution for the time being and should be as convenient as the `.conj` property.

Another reason for not doing a property is due to the unresolved discussion in #60.