### PR TITLE
Use `>>` instead of `.T` to denote transposition.

### DIFF
--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -205,8 +205,10 @@ class IndexRenamingMixin:
 class TranspositionMixin:
     '''transpose the axes by permuting the live indices into target indices.'''
     def __rshift__(self, indices):
-        return TsrEx(P.tran(self.root,
-                     P.indices(tuple([i.root for i in as_tuple(indices)]))))
+        return TsrEx(P.tran(
+            self.root,
+            P.indices(tuple([i.root for i in as_tuple(indices)]))
+        ))
 
 
 class TsrEx(_BaseEx, ArithmeticMixin, IndexRenamingMixin, TranspositionMixin):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -204,16 +204,9 @@ class IndexRenamingMixin:
 
 class TranspositionMixin:
     '''transpose the axes by permuting the live indices into target indices.'''
-    @property
-    def T(self):
-        return self._T(self.root)
-
-    class _T(_BaseEx):
-        def __getitem__(self, indices):
-            return TsrEx(
-                P.tran(self.root,
-                       P.indices(tuple([i.root for i in as_tuple(indices)])))
-            )
+    def __rshift__(self, indices):
+        return TsrEx(P.tran(self.root,
+                     P.indices(tuple([i.root for i in as_tuple(indices)]))))
 
 
 class TsrEx(_BaseEx, ArithmeticMixin, IndexRenamingMixin, TranspositionMixin):
@@ -244,6 +237,7 @@ class TensorEx(_BaseEx):
 
 
 class EinopEx(TsrEx):
+    # override the `>>` behavior from TranspositionMixin
     def __rshift__(self, output_indices):
         self.root.outidx = P.indices(
             tuple([i.root for i in as_tuple(output_indices)])

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -52,4 +52,4 @@ class ASCIIRenderer(TranscribeInterpreter):
 
     @as_payload
     def tran(self, src, indices, **kwargs):
-        return f'^T[{indices.ascii}]'
+        return f'-> [{indices.ascii}]'

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -69,4 +69,4 @@ class LatexRenderer(ROOFInterpreter):
         return body + suffix
 
     def tran(self, src, indices, **kwargs):
-        return fr'{{{src}}}^{{\mathsf{{T}}: {indices}}}'
+        return fr'{{{src}}}\rightarrow_{{{indices}}}'

--- a/funfact/lang/test_tsrex.py
+++ b/funfact/lang/test_tsrex.py
@@ -31,7 +31,7 @@ def test_transposition():
     A = tensor('A', 2, 3, 4, 5)
     i, j, k, r = indices('i, j, k, l')
     for perm in it.permutations([i, j, k, r]):
-        AT = A[i, j, k, r].T[[*perm]]
+        AT = A[i, j, k, r] >> [[*perm]]
         assert AT.root.name == 'tran'
         # TODO: More tests once
         # [#32](https://github.com/yhtang/FunFact/issues/32) is taken care of.


### PR DESCRIPTION
Closes #60. This avoids the confusion that may arise as discussed in the issue.