### PR TITLE
Bugfix/factorization view and einop

### DIFF
--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -94,7 +94,10 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
                 if c in lhs_spec and c in rhs_spec:
                     dim_lhs.append(slice(None))
                     dim_rhs.append(slice(None))
-                    kron_res.append(shape_lhs[j_l])
+                    if shape_lhs[j_l] > shape_rhs[j_r]:
+                        kron_res.append(shape_lhs[j_l])
+                    else:
+                        kron_res.append(shape_rhs[j_r])
                     j_l += 1
                     j_r += 1
                 elif c in lhs_spec:

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -70,7 +70,13 @@ class Factorization:
                 f'Index {instance} out of range (nvec: {self.nvec})'
             )
         fac = type(self)(self._otsrex, initialize=False)
-        fac.factors = [f[..., instance] for f in self.factors]
+        instance_factors = []
+        for f in self.factors:
+            if f.shape[-1] == 1:
+                instance_factors.append(f[..., 0])
+            else:
+                instance_factors.append(f[..., instance])
+        fac.factors = instance_factors
         return fac
 
     def __call__(self):


### PR DESCRIPTION
I fixed two bugs while working to fix one of the two:

- `einop` didn't work correctly if one of the tensors is initialized from data and vectorized by adding a singleton dimension
- `view` method in factorization now also works for vectorized tensors from data with a singleton dimension