### PR TITLE
Allow definition of zeroth-order tensors, i.e. scalars. Closes #69.

### DIFF
--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -232,7 +232,7 @@ class TensorEx(_BaseEx):
             P.index_notation(
                 self.root,
                 P.indices(
-                    tuple([i.root for i in as_tuple(indices)])
+                    tuple([i.root for i in as_tuple(indices or [])])
                 )
             )
         )
@@ -293,7 +293,7 @@ def tensor(*spec, initializer=None):
         symbol = None
         initializer = spec[0]
         size = initializer.shape
-    elif isinstance(spec[0], str):
+    elif len(spec) >= 1 and isinstance(spec[0], str):
         # name + size
         symbol, *size = spec
     else:

--- a/funfact/util/typing.py
+++ b/funfact/util/typing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import numpy as np
 
 
 def _is_tensor(x):
-    return hasattr(x, "__len__")
+    return isinstance(x, np.ndarray)


### PR DESCRIPTION
Since a zeroth-order tensor, i.e. a scalar, is one that does not carry any indices, it should be semantically straightforward to allow a zeroth-order tensor to be defined as one whose shape is empty (not even as `[1]`!) and which can be indexed by `[None]` (since there _is_ no indices for it). It turns out the rest of FunFact already works with zeroth-order tensors out of the box.

Example
```
a = ff.tensor('a')
b = ff.tensor()
print(a.ndim)  # expects 0
print(a.shape)  # expects (,)
print(b.live_indices)  # expects []

fac = Factorization(a[[]])
print(fac())  # obtains a single-element vector
vfac = Factorization(b[None], nvec=4)
print(vfac())  # obtains a 4-element vector
```