### PR TITLE
bugfixes + working on factorize

### DIFF
--- a/funfact/__init__.py
+++ b/funfact/__init__.py
@@ -4,7 +4,8 @@
 from .backend import use, active_backend, available_backends
 from .lang import index, indices, tensor, template, _0, _1, delta
 from .lang._math import *  # noqa: F401, F403
-
+from .model import Factorization
+from .algorithm import factorize
 
 __all__ = [
     'use',
@@ -16,7 +17,9 @@ __all__ = [
     'template',
     '_0',
     '_1',
-    'delta'
+    'delta',
+    'Factorization',
+    'factorize'
 ]
 
 

--- a/funfact/algorithm.py
+++ b/funfact/algorithm.py
@@ -1,12 +1,14 @@
 import funfact.optim
 import funfact.loss
-from funfact.model._factorization import AutoGradFactorization
-import tqdm
+from funfact import Factorization
 from funfact.backend import active_backend as ab
+import tqdm
+import numpy as np
 
 
-def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
-              optimizer='Adam', loss='mse_loss', nvec=1, **kwargs):
+def factorize(tsrex, target, lr=0.1, tol=1e-6, max_steps=10000,
+              optimizer='Adam', loss='mse_loss', nvec=1, stop_by='best',
+              **kwargs):
     '''Gradient descent optimizer for functional factorizations.
 
     Parameters
@@ -17,15 +19,23 @@ def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
         Target data tensor
     lr
         Learning rate (default: 0.1)
-    beta1
-        First order moment (default: 0.9)
-    beta2
-        Second order moment (default: 0.999)
-    epsilon
-        default: 1e-7
-    nsteps
-        Number of steps in gradient descent (default:10000)
+    tol
+        Convergence tolerance
+    max_steps
+        Maximum number of steps
+    optimizer
+        Name of optimizer
+    loss
+        Name of loss
+    nvec
+        Number of vectorizations
+    stop_by
+        'best', 'steps', int
     '''
+
+    @ab.autograd_decorator
+    class _Factorization(Factorization, ab.AutoGradMixin):
+        pass
 
     if isinstance(loss, str):
         try:
@@ -51,10 +61,11 @@ def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
                 'funfact.optim.'
             )
 
-    fac = AutoGradFactorization(tsrex, nvec=nvec)
+    opt_fac = _Factorization(tsrex, nvec=nvec)
+    best_fac = Factorization(tsrex, nvec=nvec)
 
     try:
-        opt = optimizer(fac.factors, lr=lr, **kwargs)
+        opt = optimizer(opt_fac.factors, lr=lr, **kwargs)
     except Exception:
         raise AssertionError(
             'Invalid optimization algorithm:\n{e}'
@@ -65,12 +76,48 @@ def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
         return loss(fac(), target)
     gradient = ab.jit(ab.grad(_loss))
 
-    def progressbar(n):
-        return tqdm.trange(
-                n, miniters=None, mininterval=0.25, leave=True
-            )
+    best_loss = np.ones(nvec) * np.inf
+    converged = np.zeros(nvec)
+    pbar = tqdm.tqdm(total=max_steps + 1)
 
-    for step in progressbar(max_steps):
-        opt.step(gradient(fac, target).factors)
+    for step in range(max_steps):
+        pbar.update(1)
+        opt.step(gradient(opt_fac, target).factors)
 
-    return fac
+        if step % round(max_steps/20) == 0:
+            # update best factorization
+            curr_loss = loss(opt_fac(), target, sum_vec=False)
+            new_best = []
+            for b, o in zip(best_fac.factors, opt_fac.factors):
+                for i, l in enumerate(zip(curr_loss, best_loss)):
+                    if l[0] < l[1]:
+                        if b.shape[-1] == 1:
+                            # TODO: this weird way of updating is required
+                            # by JAX
+                            b = b.at[..., 0].set(o[..., 0])
+                        else:
+                            b = b.at[..., i].set(o[..., i])
+                        if l[0] < tol:
+                            converged[i] = 1
+                new_best.append(b)
+            best_fac.factors = new_best
+
+            if stop_by == 'best':
+                if np.sum(converged) > 1:
+                    pbar.update(max_steps - step)
+                    break
+            elif isinstance(stop_by, int):
+                if np.sum(converged) > stop_by:
+                    pbar.update(max_steps - step)
+                    break
+    pbar.close()
+
+    if stop_by == 'best':
+        return best_fac.view(np.argmin(best_loss))
+    elif stop_by == 'steps':
+        return best_fac
+    elif isinstance(stop_by, int):
+        sort_idx = np.argsort(best_loss)
+        return [best_fac.view(sort_idx[i]) for i in range(stop_by)]
+    else:
+        raise ValueError(f'Unsupported value for stop_by: {stop_by}')

--- a/funfact/algorithm.py
+++ b/funfact/algorithm.py
@@ -1,0 +1,75 @@
+from jax import grad, jit
+import funfact.optim
+import funfact.loss
+from funfact import Factorization
+import tqdm
+
+
+def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
+              optimizer='Adam', loss='mse_loss', nvec=1, **kwargs):
+    '''Gradient descent optimizer for functional factorizations.
+
+    Parameters
+    ----------
+    tsrex: TsrEx
+        A FunFact tensor expression.
+    target
+        Target data tensor
+    lr
+        Learning rate (default: 0.1)
+    beta1
+        First order moment (default: 0.9)
+    beta2
+        Second order moment (default: 0.999)
+    epsilon
+        default: 1e-7
+    nsteps
+        Number of steps in gradient descent (default:10000)
+    '''
+
+    if isinstance(loss, str):
+        try:
+            loss = getattr(funfact.loss, loss)
+        except AttributeError:
+            raise AttributeError(
+                f'The loss function \'{loss}\' does not exist in'
+                'funfact.loss.'
+            )
+    try:
+        loss(target, target, **kwargs)
+    except Exception as e:
+        raise AssertionError(
+            f'The given loss function does not accept two arguments:\n{e}'
+        )
+
+    if isinstance(optimizer, str):
+        try:
+            optimizer = getattr(funfact.optim, optimizer)
+        except AttributeError:
+            raise AttributeError(
+                f'The optimizer \'{optimizer}\' does not exist in'
+                'funfact.optim.'
+            )
+    fac = Factorization(tsrex, nvec=nvec)
+
+    try:
+        opt = optimizer(fac.factors, lr=lr, **kwargs)
+    except Exception:
+        raise AssertionError(
+            'Invalid optimization algorithm:\n{e}'
+        )
+
+    @jit
+    def _loss(fac, target):
+        return loss(fac(), target)
+    gradient = jit(grad(_loss))
+
+    def progressbar(n):
+        return tqdm.trange(
+                n, miniters=None, mininterval=0.25, leave=True
+            )
+
+    for step in progressbar(max_steps):
+        opt.step(gradient(fac, target).factors)
+
+    return fac

--- a/funfact/algorithm.py
+++ b/funfact/algorithm.py
@@ -1,8 +1,8 @@
-from jax import grad, jit
 import funfact.optim
 import funfact.loss
-from funfact import Factorization
+from funfact.model._factorization import AutoGradFactorization
 import tqdm
+from funfact.backend import active_backend as ab
 
 
 def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
@@ -50,7 +50,8 @@ def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
                 f'The optimizer \'{optimizer}\' does not exist in'
                 'funfact.optim.'
             )
-    fac = Factorization(tsrex, nvec=nvec)
+
+    fac = AutoGradFactorization(tsrex, nvec=nvec)
 
     try:
         opt = optimizer(fac.factors, lr=lr, **kwargs)
@@ -59,10 +60,10 @@ def factorize(tsrex, target, lr=0.1, tol=1e-4, max_steps=10000,
             'Invalid optimization algorithm:\n{e}'
         )
 
-    @jit
+    @ab.jit
     def _loss(fac, target):
         return loss(fac(), target)
-    gradient = jit(grad(_loss))
+    gradient = ab.jit(ab.grad(_loss))
 
     def progressbar(n):
         return tqdm.trange(

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -4,6 +4,8 @@ import os
 import numpy as np
 import jax.numpy as jnp
 import jax.random as jrn
+import jax
+from jax.tree_util import register_pytree_node_class
 from ._meta import BackendMeta
 
 
@@ -27,3 +29,24 @@ class JAXBackend(metaclass=BackendMeta):
     def normal(cls, mean, std, *shape, dtype=jnp.float32):
         cls._key, subkey = jrn.split(cls._key)
         return mean + std * jrn.normal(subkey, shape, dtype)
+
+    @staticmethod
+    def grad(*args, **kwargs):
+        return jax.grad(*args, **kwargs)
+
+    @staticmethod
+    def jit(*args, **kwargs):
+        return jax.jit(*args, **kwargs)
+
+    def autograd_decorator(*args, **kwargs):
+        return register_pytree_node_class(*args, **kwargs)
+
+    class AutoGradMixin():
+        def tree_flatten(self):
+            return list(self.factors), self.tsrex
+
+        @classmethod
+        def tree_unflatten(cls, tsrex, tensors):
+            unflatten = cls(tsrex, initialize=False)
+            unflatten.factors = tensors
+            return unflatten

--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -104,7 +104,7 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
     op_pair = getattr(ab, pairwise)
 
     # reorder contraction according to out_spec
-    dictionary = dict(zip(indices_rem, ab.arange(len(indices_rem))))
+    dictionary = dict(zip(indices_rem, np.arange(len(indices_rem))))
     res_order = [dictionary[key] for key in out_spec]
 
     return ab.transpose(

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -11,7 +11,8 @@ class Loss(ABC):
     def _loss(self, model, target):
         pass
 
-    def __call__(self, model, target, reduction='mean', sum_vec=True):
+    def __call__(self, model, target, reduction='mean', sum_vec=True,
+                 **kwargs):
         if target.ndim == model.ndim - 1:
             if model.shape[:-1] != target.shape:
                 raise ValueError(f'Target shape {target.shape} and '

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -12,10 +12,9 @@ from funfact.lang.interpreter import (
     ShapeAnalyzer,
     Vectorizer
 )
-from jax.tree_util import register_pytree_node_class
+from funfact.backend import active_backend as ab
 
 
-@register_pytree_node_class
 class Factorization:
     '''A factorization model is a concrete realization of a tensor expression.
     The factor tensors of the model can be optimized to obtain a better
@@ -197,11 +196,7 @@ class Factorization:
         ):
             n.data = tensors[i]
 
-    def tree_flatten(self):
-        return list(self.factors), self.tsrex
 
-    @classmethod
-    def tree_unflatten(cls, tsrex, tensors):
-        unflatten = cls(tsrex, initialize=False)
-        unflatten.factors = tensors
-        return unflatten
+@ab.autograd_decorator
+class AutoGradFactorization(Factorization, ab.AutoGradMixin):
+    pass

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -12,7 +12,6 @@ from funfact.lang.interpreter import (
     ShapeAnalyzer,
     Vectorizer
 )
-from funfact.backend import active_backend as ab
 
 
 class Factorization:
@@ -195,8 +194,3 @@ class Factorization:
             dfs_filter(lambda n: n.name == 'tensor', self.tsrex.root)
         ):
             n.data = tensors[i]
-
-
-@ab.autograd_decorator
-class AutoGradFactorization(Factorization, ab.AutoGradMixin):
-    pass


### PR DESCRIPTION
Implements #70 and towards #55

The `factorize` function now works with a vectorized approach. It can give three types of outputs:

- `stop_by='best'`: returns a single (unvectorized) factorization model that has the best fit
- `stop_by=int`: returns a list of unvectorized factorization models that have the `stop_by` (<=nvec) best fits
- 'stop_by='steps' : returns a vectorized factorization model containing the `nvec` best approximations