### PR TITLE
Documentation + unit tests for `funfact.lang._terminal`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,3 +1,1 @@
-<!-- # funfact.tensor -->
-
 ::: funfact.index

--- a/docs/api/indices.md
+++ b/docs/api/indices.md
@@ -1,3 +1,1 @@
-<!-- # funfact.tensor -->
-
 ::: funfact.indices

--- a/docs/tsrex.md
+++ b/docs/tsrex.md
@@ -1,0 +1,55 @@
+## Embedded Domain-Specific Language (eDSL) for Tensor Expressions
+
+Related file:
+
+- `funfact/lang/_primitive.py`
+- `funfact/lang/_tsrex.py`
+
+A **t**en**s**o**r** **ex**pression (**tsrex**) is an index notation system with a few extensions to the Einstein summation convention.
+
+Below is the grammar of tsrex in BNF:
+
+``` BNF
+tsrex -> f(tsrex) |
+         tsrex binary_operator tsrex |
+         unary_operator tsrex |
+         index_notation |
+         scalar
+
+index_notation -> tensor[indices]
+
+indices -> indices,index |
+           index
+```
+
+where the terminal symbols are
+
+```BNF
+f -> abs   |
+     exp   | log   |
+     sin   | cos   | tan   |
+     asin  | acos  | atan  | atan2  |
+     sinh  | cosh  | tanh  |
+     asinh | acosh | atanh |
+     erf   | erfc  |
+     ...
+
+binary_operator -> * |
+                   / |
+                   + |
+                   - |
+                   ** | 
+                   % |
+                   ...
+
+unary_operator -> - |
+                  ...
+
+tensor -> identifier
+
+index -> identifier
+
+identifier -> ([a-zA-Z]+)(?:_([a-zA-Z\d]+))?
+
+scalar -> real
+```

--- a/funfact/lang/_terminal.py
+++ b/funfact/lang/_terminal.py
@@ -35,9 +35,14 @@ class Symbol:
             self.letter, self.number = self._make_symbol(identifier)
         else:
             raise RuntimeError(f'Cannot create symbol from {identifier}.')
+        if self.number is not None:
+            self.number = str(self.number)
 
     def __repr__(self):
-        return f'{type(self).__qualname__}({self.letter}, {self.number})'
+        return '{typename}({identifier})'.format(
+            typename=type(self).__qualname__,
+            identifier=repr((self.letter, self.number))
+        )
 
     def __str__(self):
         letter = self.letter or ''
@@ -89,7 +94,11 @@ class LiteralValue(Identifiable, LaTexReprMixin):
         return str(self.raw)
 
     def __repr__(self):
-        return f'{type(self).__qualname__}({str(self.raw)}, {self.latex})'
+        return '{typename}({raw}, {latex})'.format(
+            typename=type(self).__qualname__,
+            raw=repr(self.raw),
+            latex=repr(self.latex),
+        )
 
     def _repr_tex_(self):
         return self.latex or str(self)

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -272,9 +272,9 @@ def indices(spec):
     Args:
         spec (int or str):
 
-            - If `int`, indicate the number of 'anonymous' index variables to create.
-            These anonymous variables will be numbered sequentially starting from
-            0, and are guaranteed to be unique within runtime.
+            - If `int`, indicate the number of 'anonymous' index variables to
+            create. These anonymous variables will be numbered sequentially
+            starting from 0, and are guaranteed to be unique within runtime.
             - If `str`, must be a
             comma-separate list of symbols in the format as described in
             [funfact.index][].
@@ -311,18 +311,18 @@ def tensor(*spec, initializer=None):
         spec (multiple):
             Formats supported:
 
-            * symbol, size...: a alphanumeric symbol followed by the size for each
-                            dimension.
-            * size...: size of each dimension.
-            * symbol, tensor: a alphanumeric symbol followed by a concrete tensor
-                            such as ``np.eye(3)`` or ``rand(10, 7)``.
-            * tensor: a concrete tensor.
+            * `symbol, size...`: a alphanumeric symbol followed by the size for
+            each dimension.
+            * `size...`: size of each dimension.
+            * `symbol, tensor`: a alphanumeric symbol followed by a concrete
+            tensor such as ``np.eye(3)`` or ``rand(10, 7)``.
+            * `tensor`: a concrete tensor.
 
         initializer (callable):
             Initialization distribution
 
     Returns:
-        TsrEx: A tensor expression representing a single tensor object.
+        TsrEx: A tensor expression representing an abstract tensor object.
     '''
     if len(spec) == 2 and isinstance(spec[0], str) and ab.is_tensor(spec[1]):
         # name + concrete tensor

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -248,10 +248,54 @@ class EinopEx(TsrEx):
 
 
 def index(symbol=None):
+    '''Create an index variable.
+
+    Args:
+        symbol (str):
+            A human-readable symbol.
+            The symbol will be used for screen printing and LaTeX rendering.
+            Must conform to the format described by the tsrex formal grammar.
+
+    !!! note
+        The symbol is only meant for human comprehension and is not used in
+        equality/identity tests of the indices.
+
+    Returns:
+        TsrEx: A single-index tensor expression.
+    '''
     return IndexEx(P.index(AbstractIndex(symbol), bound=False, kron=False))
 
 
 def indices(spec):
+    '''Create multiple index varaibles at once.
+
+    Args:
+        spec (int or str):
+
+            - If `int`, indicate the number of 'anonymous' index variables to create.
+            These anonymous variables will be numbered sequentially starting from
+            0, and are guaranteed to be unique within runtime.
+            - If `str`, must be a
+            comma-separate list of symbols in the format as described in
+            [funfact.index][].
+
+    Returns:
+        tuple: Multiple single-index tensor expressions.
+
+    Example:
+
+        >>> i, j = indices(2); i
+
+        $$i$$
+
+        >>> i, j, k = indices('i, j, k'); k
+
+        $$k$$
+
+        >>> I = indices(9); I[0]
+
+        $$\\#_0$$
+    '''
     if isinstance(spec, int):
         return [index() for i in range(spec)]
     elif isinstance(spec, str):
@@ -263,25 +307,22 @@ def indices(spec):
 def tensor(*spec, initializer=None):
     '''Construct an abstract tensor using `spec`.
 
-    Parameters
-    ----------
-    spec:
-        Formats supported:
+    Args:
+        spec (multiple):
+            Formats supported:
 
-        * symbol, size...: a alphanumeric symbol followed by the size for each
-                           dimension.
-        * size...: size of each dimension.
-        * symbol, tensor: a alphanumeric symbol followed by a concrete tensor
-                          such as ``np.eye(3)`` or ``rand(10, 7)``.
-        * tensor: a concrete tensor.
+            * symbol, size...: a alphanumeric symbol followed by the size for each
+                            dimension.
+            * size...: size of each dimension.
+            * symbol, tensor: a alphanumeric symbol followed by a concrete tensor
+                            such as ``np.eye(3)`` or ``rand(10, 7)``.
+            * tensor: a concrete tensor.
 
-    initializer:
-        Initialization distribution
+        initializer (callable):
+            Initialization distribution
 
-    Returns
-    -------
-    tsrex: _BaseEx
-        A tensor expression representing a single tensor object.
+    Returns:
+        TsrEx: A tensor expression representing a single tensor object.
     '''
     if len(spec) == 2 and isinstance(spec[0], str) and ab.is_tensor(spec[1]):
         # name + concrete tensor

--- a/funfact/lang/test_terminal.py
+++ b/funfact/lang/test_terminal.py
@@ -1,18 +1,122 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
+import uuid
+import multiprocessing
 import numpy as np
-from ._terminal import AbstractIndex, AbstractTensor
+from ._terminal import (
+    Symbol,
+    Identifiable,
+    LiteralValue,
+    AbstractIndex,
+    AbstractTensor,
+)
 
 
-def test_abstract_index():
+@pytest.mark.parametrize(
+    'identifier', [
+        ('a', '1'),
+        ('a', None),
+        'a_1',
+        'a'
+    ]
+)
+def test_symbol_init(identifier):
+    print('identifier', identifier)
+    s = Symbol(identifier)
+    assert s.letter == 'a'
+    assert (s.number.isdigit() if s.number is not None else True)
+    assert not repr(s).startswith('<')
+    assert not repr(s).endswith('>')
+    assert str(s) != repr(s)
+    assert s.letter in str(s)
+    assert repr(s) == repr(eval(repr(s)))
+
+
+@pytest.mark.parametrize(
+    'invalid_identifier', [
+        '123',
+        '123_123',
+        '123_a',
+        '_1',
+        '__1',
+        '1_2_3',
+        'a_1_1',
+        'a_b_c',
+        123,
+        123.0,
+        True,
+        None
+    ]
+)
+def test_symbol_init_exception(invalid_identifier):
+    with pytest.raises(RuntimeError):
+        Symbol(invalid_identifier)
+
+
+def test_symbol_init_by_uuid():
+    class MockSpecializedSymbol(Symbol):
+        _anon_registry = {}
+        _anon_registry_lock = multiprocessing.Lock()
+
+    u = uuid.uuid4()
+    v = uuid.uuid4()
+
+    r = MockSpecializedSymbol(u)
+    assert r.letter is None
+    assert r.number.isdigit()
+
+    s = MockSpecializedSymbol(v)
+    assert s.letter is None
+    assert s.number.isdigit()
+
+    t = MockSpecializedSymbol(u)
+    assert t.letter is None
+    assert t.number == r.number
+
+
+def test_identifiable():
+    a = Identifiable()
+    b = Identifiable()
+    assert a == a
+    assert b == b
+    assert a != b
+    assert hash(a) == hash(a)
+    assert hash(b) == hash(b)
+    assert hash(a) != hash(b)
+
+
+def test_literal_value():
+    _0_tex = r'\mathbf{0}'
+    _0 = LiteralValue(0, _0_tex)
+    assert isinstance(_0, Identifiable)
+    assert str(0) in str(_0)
+    assert repr(_0) == repr(eval(repr(_0)))
+    assert _0._repr_tex_() == _0_tex
+
+
+@pytest.mark.parametrize(
+    'symbol', [
+        'i',
+        'i_1',
+    ]
+)
+def test_abstract_index(symbol):
+
+    i = AbstractIndex(symbol)
+    assert i == i
+    assert isinstance(repr(i), str)
+    assert isinstance(str(i), str)
+    assert isinstance(i._repr_tex_(), str)
+    assert r'\bar' in i._repr_tex_(accent=r'\bar')
+    assert i._repr_tex_() in i._repr_html_()
+
+
+def test_abstract_index_equality():
 
     i = AbstractIndex()
     j = AbstractIndex()
     k = AbstractIndex('k_1')
-    assert i == i
-    assert j == j
-    assert k == k
     assert i != j
     assert i != k
     assert j != k
@@ -20,11 +124,6 @@ def test_abstract_index():
     assert hash(i) != hash(j)
     assert hash(i) != hash(k)
     assert hash(j) != hash(k)
-
-    assert isinstance(repr(i), str)
-    assert isinstance(str(i), str)
-    assert isinstance(i._repr_tex_(), str)
-    assert isinstance(i._repr_html_(), str)
 
 
 def test_abstract_tensor():
@@ -34,6 +133,12 @@ def test_abstract_tensor():
     w = AbstractTensor(9, 2, initializer=np.random.rand)
     x = AbstractTensor(4, 2, 3, symbol='x')
     y1 = AbstractTensor(4, 2, 3, symbol='y_1')
+
+    with pytest.raises(RuntimeError):
+        AbstractTensor(-1)
+    with pytest.raises(RuntimeError):
+        AbstractTensor('a', -2, -3)
+
     assert u.ndim == 1
     assert v.ndim == 2
     assert w.ndim == 2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,9 @@ theme:
 plugins:
   - search
   - autorefs
-  - mkdocstrings
+  - mkdocstrings:
+      watch:
+        - funfact
   # - gen-files:
   #     scripts:
   #     - docs/gen_ref_nav.py
@@ -21,7 +23,9 @@ nav:
     - Installation: installation.md
     - Examples:
       - Nonlinear matrix approximation: "examples/nma.md"
-    - User Guide: user_guide.md
+    - User Guide:
+        Overview: user_guide.md
+        Grammar reference: tsrex.md
     - API Reference:
         "funfact.tensor": api/tensor.md
         "funfact.index": api/index.md


### PR DESCRIPTION
This PR provides furnished docstrings for the public APIs of the ~~`funfact.lang._terminal`~~ `funfact.lang._tsrex` module, and also added enough tests to achieve 99% coverage ratio for `funfact.lang._terminal`.

correction