### PR TITLE
Full functionality for using the PyTorch backend. Fixes #76. Fixes #98.

### DIFF
--- a/funfact/algorithm.py
+++ b/funfact/algorithm.py
@@ -62,6 +62,8 @@ def factorize(
             that represents all the solutions.
     '''
 
+    target = ab.tensor(target)
+
     @ab.autograd_decorator
     class _Factorization(Factorization, ab.AutoGradMixin):
         pass
@@ -92,7 +94,6 @@ def factorize(
 
     tsrex_vec = vectorize(tsrex, nvec)
     opt_fac = _Factorization.from_tsrex(tsrex_vec)
-    best_fac = Factorization.from_tsrex(tsrex_vec)
 
     try:
         opt = optimizer(opt_fac.factors, lr=lr, **kwargs)
@@ -101,52 +102,53 @@ def factorize(
             'Invalid optimization algorithm:\n{e}'
         )
 
-    @ab.jit
-    def _loss(fac, target):
-        return loss(fac(), target)
-    gradient = ab.jit(ab.grad(_loss))
+    loss_and_grad = ab.loss_and_grad(loss, opt_fac, target)
 
+    # bookkeeping
+    best_factors = [np.zeros_like(ab.to_numpy(x)) for x in opt_fac.factors]
     best_loss = np.ones(nvec) * np.inf
     converged = np.zeros(nvec)
     pbar = tqdm.tqdm(total=max_steps + 1)
 
     for step in range(max_steps):
         pbar.update(1)
-        opt.step(gradient(opt_fac, target).factors)
+        _, grad = loss_and_grad(opt_fac, target)
+        with ab.no_grad():
+            opt.step(grad)
 
-        if step % round(max_steps/20) == 0:
-            # update best factorization
-            curr_loss = loss(opt_fac(), target, sum_vec=False)
-            new_best = []
-            for b, o in zip(best_fac.factors, opt_fac.factors):
-                for i, l in enumerate(zip(curr_loss, best_loss)):
-                    if l[0] < l[1]:
-                        if b.shape[-1] == 1:
-                            # TODO: this weird way of updating is required
-                            # by JAX
-                            b = b.at[..., 0].set(o[..., 0])
-                        else:
-                            b = b.at[..., i].set(o[..., i])
-                        if l[0] < tol:
-                            converged[i] = 1
-                new_best.append(b)
-            best_fac.factors = new_best
+            if step % round(max_steps/20) == 0:
+                # update best factorization
+                curr_loss = loss(opt_fac(), target, sum_vec=False)
+                new_best = []
+                for b, o in zip(best_factors, opt_fac.factors):
+                    for i, l in enumerate(zip(curr_loss, best_loss)):
+                        if l[0] < l[1]:
+                            if b.shape[-1] == 1:
+                                b[..., 0] = o[..., 0]
+                            else:
+                                b[..., i] = o[..., i]
+                            if l[0] < tol:
+                                converged[i] = 1
+                    new_best.append(b)
+                best_factors = new_best
 
-            if stop_by == 'first':
-                if np.any(converged):
-                    pbar.update(max_steps - step)
-                    break
-            elif isinstance(stop_by, int):
-                if np.count_nonzero(converged) >= stop_by:
-                    pbar.update(max_steps - step)
-                    break
-            else:
-                if stop_by is not None:
-                    raise RuntimeError(
-                        f'Invalid argument value for stop_by: {stop_by}'
-                    )
+                if stop_by == 'first':
+                    if np.any(converged):
+                        pbar.update(max_steps - step)
+                        break
+                elif isinstance(stop_by, int):
+                    if np.count_nonzero(converged) >= stop_by:
+                        pbar.update(max_steps - step)
+                        break
+                else:
+                    if stop_by is not None:
+                        raise RuntimeError(
+                            f'Invalid argument value for stop_by: {stop_by}'
+                        )
     pbar.close()
 
+    best_fac = Factorization.from_tsrex(tsrex_vec)
+    best_fac.factors = [ab.tensor(x) for x in best_factors]
     if returns == 'best':
         return view(best_fac, tsrex, np.argmin(best_loss))
     elif isinstance(returns, int):

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -48,12 +48,8 @@ class PyTorchBackend(metaclass=BackendMeta):
                 f'Unsupported option for reshape order: {order}.'
             )
 
-    @classmethod
-    def sum(cls, a, axis):
-        if not axis:
-            return a
-        else:
-            return torch.sum(a, axis)
+    def autograd_decorator(ob):
+        return ob
 
     class AutoGradMixin():
         def __iter__(self):

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -29,3 +29,24 @@ class PyTorchBackend(metaclass=BackendMeta):
     def transpose(cls, a, axes):
         '''torch equivalent is torch.permute'''
         return torch.permute(a, (*axes,))
+
+    @classmethod
+    def reshape(cls, a, newshape, order='C'):
+        if order == 'C':
+            return torch.reshape(a, (*newshape,))
+        elif order == 'F':
+            if len(a.shape) > 0:
+                a = a.permute(*reversed(range(len(a.shape))))
+            return a.reshape(*reversed(newshape)).permute(
+                      *reversed(range(len(newshape))))
+        else:
+            raise ValueError(
+                f'Unsupported option for reshape order: {order}.'
+            )
+
+    @classmethod
+    def sum(cls, a, axis):
+        if not axis:
+            return a
+        else:
+            return torch.sum(a, axis)

--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -109,17 +109,30 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
     dictionary = dict(zip(indices_rem, np.arange(len(indices_rem))))
     res_order = [dictionary[key] for key in out_spec]
 
-    return ab.transpose(
-        ab.reshape(
-            op_redu(
+    if not con_ax:
+        return ab.transpose(
+            ab.reshape(
                 op_pair(
                     lhs[tuple(dim_lhs)],
                     rhs[tuple(dim_rhs)]
                 ),
-                axis=tuple(con_ax)
+                tuple(kron_res),
+                order='F'
             ),
-            tuple(kron_res),
-            order='F'
-        ),
-        res_order
-    )
+            res_order
+        )
+    else:
+        return ab.transpose(
+            ab.reshape(
+                op_redu(
+                    op_pair(
+                        lhs[tuple(dim_lhs)],
+                        rhs[tuple(dim_rhs)]
+                    ),
+                    tuple(con_ax)
+                ),
+                tuple(kron_res),
+                order='F'
+            ),
+            res_order
+        )

--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -105,34 +105,23 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
     op_redu = getattr(ab, reduction)
     op_pair = getattr(ab, pairwise)
 
+    def op_redu_overload(tensor):
+        return op_redu(tensor, tuple(con_ax)) if con_ax else tensor
+
     # reorder contraction according to out_spec
     dictionary = dict(zip(indices_rem, np.arange(len(indices_rem))))
     res_order = [dictionary[key] for key in out_spec]
 
-    if not con_ax:
-        return ab.transpose(
-            ab.reshape(
+    return ab.transpose(
+        ab.reshape(
+            op_redu_overload(
                 op_pair(
                     lhs[tuple(dim_lhs)],
                     rhs[tuple(dim_rhs)]
                 ),
-                tuple(kron_res),
-                order='F'
             ),
-            res_order
-        )
-    else:
-        return ab.transpose(
-            ab.reshape(
-                op_redu(
-                    op_pair(
-                        lhs[tuple(dim_lhs)],
-                        rhs[tuple(dim_rhs)]
-                    ),
-                    tuple(con_ax)
-                ),
-                tuple(kron_res),
-                order='F'
-            ),
-            res_order
-        )
+            tuple(kron_res),
+            order='F'
+        ),
+        res_order
+    )

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -37,7 +37,7 @@ class Loss(ABC):
                 f'{reduction} instead.'
             )
         if sum_vec:
-            return ab.sum(_loss, axis=None)
+            return ab.sum(_loss)
         else:
             return _loss
 


### PR DESCRIPTION
This fixes #76, I haven't checked the performance of the  `reshape(..., order='F')` implementation.

The `torch.sum` method is overridden to have the same behavior as `numpy` if axis is an empty tuple. The same will have to be don for other reduction operations: `torch.prod`, `torch.max`, `torch.min`, ...