### PR TITLE
Add pytorch to project dependency

### DIFF
--- a/funfact/backend/test_backend.py
+++ b/funfact/backend/test_backend.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
-import importlib
+import os
 from . import (
     _active_backend,
     _use_default_backend,
@@ -17,8 +17,11 @@ def test_import():
 
 def test_available_backends():
     for backend, clsname in available_backends.items():
-        assert hasattr(
-            importlib.import_module(f'funfact.backend._{backend}'), clsname
+        assert os.path.exists(
+            os.path.join(
+                os.path.dirname(__file__),
+                f'_{backend}.py'
+            )
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 pycuda>=2021.1
+torch
+torchvision
+torchaudio

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,14 @@ setup(
         'matplotlib>=3.4',
         'scipy>=1.7.1',
         'asciitree>=0.3.3',
-        'jax[cpu]>=0.2.24',
     ],
     extras_require={
+        'jax': [
+            'jax>=0.2.24',
+        ],
+        'torch': [
+            'torch>=1.9',
+        ],
         'docs': [
             'mkdocs==1.2.3',
             'mkdocs-gen-files==0.3.3',


### PR DESCRIPTION
Added the `[jax]` and `[torch]` installation targets.

Examples:
``` bash
pip install funfact  # numpy only
pip install funfact[jax]  # installs JAX
pip install funfact[torch]  # installs PyTorch
```