### PR TITLE
Towards #38

### DIFF
--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -18,7 +18,7 @@ class JAXBackend(metaclass=BackendMeta):
     tensor_t = (jnp.ndarray, np.ndarray)
 
     @classmethod
-    def tensor(cls, array, **kwargs):
+    def tensor(cls, array, optimizable, **kwargs):
         return jnp.asarray(array, **kwargs)
 
     @classmethod
@@ -26,7 +26,7 @@ class JAXBackend(metaclass=BackendMeta):
         cls._key = jrn.PRNGKey(key)
 
     @classmethod
-    def normal(cls, mean, std, *shape, dtype=jnp.float32):
+    def normal(cls, mean, std, *shape, optimizable, dtype=jnp.float32):
         cls._key, subkey = jrn.split(cls._key)
         return mean + std * jrn.normal(subkey, shape, dtype)
 

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -14,16 +14,18 @@ class PyTorchBackend(metaclass=BackendMeta):
     tensor_t = (torch.Tensor, np.ndarray)
 
     @classmethod
-    def tensor(cls, array, **kwargs):
-        return torch.tensor(array, **kwargs)
+    def tensor(cls, array, optimizable, **kwargs):
+        return torch.tensor(array, requires_grad=optimizable, **kwargs)
 
     @classmethod
     def seed(cls, key):
         cls._gen.manual_seed(key)
 
     @classmethod
-    def normal(cls, mean, std, *shape, dtype=torch.float32):
-        return torch.normal(mean, std, shape, dtype=dtype, generator=cls._gen)
+    def normal(cls, mean, std, *shape, optimizable, dtype=torch.float32):
+        return torch.normal(mean, std, shape, dtype=dtype,
+                            generator=cls._gen).clone().detach().\
+                                requires_grad_(optimizable)
 
     @classmethod
     def transpose(cls, a, axes):

--- a/funfact/lang/_terminal.py
+++ b/funfact/lang/_terminal.py
@@ -152,7 +152,7 @@ class AbstractTensor(Identifiable, LaTexReprMixin):
         _anon_registry = {}
         _anon_registry_lock = multiprocessing.Lock()
 
-    def __init__(self, *size, symbol=None, initializer=None):
+    def __init__(self, *size, symbol=None, initializer=None, optimizable=None):
         super().__init__()
         for d, n in enumerate(size):
             if not (isinstance(n, numbers.Integral) and n > 0):
@@ -163,6 +163,7 @@ class AbstractTensor(Identifiable, LaTexReprMixin):
         self._shape = tuple(map(int, size))
         self.symbol = self.TensorSymbol(symbol or self.uuid)
         self.initializer = initializer
+        self._optimizable = optimizable
 
     @property
     def shape(self):
@@ -171,6 +172,10 @@ class AbstractTensor(Identifiable, LaTexReprMixin):
     @property
     def ndim(self):
         return len(self._shape)
+    
+    @property
+    def optimizable(self):
+        return self._optimizable
 
     def __str__(self):
         return str(self.symbol)
@@ -191,3 +196,6 @@ class AbstractTensor(Identifiable, LaTexReprMixin):
             return fr'\boldsymbol{{{letter}}}^{{({number})}}'
         else:
             return fr'\boldsymbol{{{letter}}}'
+
+    def set_optimizable(self, optimizable):
+        self._optimizable = optimizable

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -308,7 +308,7 @@ def indices(spec):
         raise RuntimeError(f'Cannot create indices from {spec}.')
 
 
-def tensor(*spec, initializer=None):
+def tensor(*spec, initializer=None, optimizable=None):
     '''Construct an abstract tensor using `spec`.
 
     Args:
@@ -325,6 +325,10 @@ def tensor(*spec, initializer=None):
         initializer (callable):
             Initialization distribution
 
+        optimizable (boolean):
+            True/False flag indicating if tensor leaf should be optimized,
+            default value is True
+
     Returns:
         TsrEx: A tensor expression representing an abstract tensor object.
     '''
@@ -333,18 +337,26 @@ def tensor(*spec, initializer=None):
         symbol = spec[0]
         initializer = spec[1]
         size = initializer.shape
+        if optimizable is None:
+            optimizable = False
     elif len(spec) == 1 and ab.is_tensor(spec[0]):
         # concrete tensor only
         symbol = None
         initializer = spec[0]
         size = initializer.shape
+        if optimizable is None:
+            optimizable = False
     elif len(spec) >= 1 and isinstance(spec[0], str):
         # name + size
         symbol, *size = spec
+        if optimizable is None:
+            optimizable = True
     else:
         # size only
         symbol = None
         size = spec
+        if optimizable is None:
+            optimizable = True
 
     for d in size:
         if not (isinstance(d, int) and d > 0):
@@ -353,5 +365,6 @@ def tensor(*spec, initializer=None):
             )
 
     return TensorEx(P.tensor(
-        AbstractTensor(*size, symbol=symbol, initializer=initializer))
-    )
+        AbstractTensor(*size, symbol=symbol, initializer=initializer,
+                       optimizable=optimizable))
+                    )

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -20,11 +20,13 @@ class LeafInitializer(TranscribeInterpreter):
     def tensor(self, abstract, **kwargs):
         if abstract.initializer is not None:
             if not callable(abstract.initializer):
-                init_val = ab.tensor(abstract.initializer)
+                init_val = ab.tensor(abstract.initializer,
+                                     optimizable=abstract.optimizable)
             else:
                 init_val = abstract.initializer(abstract.shape)
         else:
-            init_val = ab.normal(0.0, 1.0, *abstract.shape)
+            init_val = ab.normal(0.0, 1.0, *abstract.shape,
+                                 optimizable=abstract.optimizable)
         return init_val
 
     @as_payload

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -183,7 +183,8 @@ class Factorization:
         its children. For use with a gradient optimizer.'''
         return self._NodeView(
             'data',
-            list(dfs_filter(lambda n: n.name == 'tensor', self.tsrex.root))
+            list(dfs_filter(lambda n: n.name == 'tensor' and
+                            n.abstract.optimizable, self.tsrex.root))
         )
 
     @factors.setter
@@ -191,6 +192,7 @@ class Factorization:
         '''A flattened list of optimizable parameters of the primitive and all
         its children. For use with a gradient optimizer.'''
         for i, n in enumerate(
-            dfs_filter(lambda n: n.name == 'tensor', self.tsrex.root)
+            dfs_filter(lambda n: n.name == 'tensor' and
+                       n.abstract.optimizable, self.tsrex.root)
         ):
             n.data = tensors[i]


### PR DESCRIPTION
This draft PR is meant to implement #38 

I see two remaining issues with current version:

- `set_optimizable` function is part of `AbstractTensor`. This has the following effect:
```Python
a = ff.tensor(2, 3, 4)
a.set_optimizable(False) # This doesnt work
a.root.abstract.set_optimizable(False) # This does work but is too complicated
```

- If `set_optimizable` is changed _after_ the leaf initializer is run, it will work for a JAX backend (the `dfs_filter` should be sufficient), but it won't work properly for torch as we need to change the `requires_grad` flag of the tensor. Maybe we can check in the `set_optimizable` function if: (1) the backend is torch, and (2) the tensor is already initialized and change the `requires_grad` flag.

What do you think @yhtang ?