### PR TITLE
More information about installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,14 +16,13 @@ cd FunFact/
 python setup.py install
 ```
 
-# Autograd backends
+## Autograd backends
 
-The default installation of FunFact installs the NumPy backend which only
-supports forward calculations. The NumPy backend doesn't support backpropagation
-and is not able to optimize tensor expressions for target data.
+The default installation of FunFact installs the NumPy backend, which only
+supports forward calculations. The NumPy backend doesn't support automatic differentiation
+and is not able to optimize tensor expressions for methods such as [funfact.factorize](funfact.factorize).
 
-In order to factorize data in a functional expression two other backends are
-supported:
+In order to factorize tensor data by a tensor expression, two other backends are provides:
 
   * [JAX](https://jax.readthedocs.io/en/latest/) backend. Detailed 
   installation instructions for JAX can be found [here](https://github.com/google/jax#installation). Alternatively, use:
@@ -38,9 +37,9 @@ supported:
   pip install "funfact[torch]"
   ``` 
 
-# Extras
+## Development dependencies
 
-Two other extras are with additional dependencies are supported. 
+There are two additional sets of dependencies useful for developers:
 
  * To install all dependencies for generating FunFact documentation, use:
   ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+There are two options to install FunFact: either from PyPI or directly from source.
+
 ## Install stable versions from [Python Package Index](https://pypi.org/project/funfact/)
 
 ```bash
@@ -13,3 +15,39 @@ git clone https://github.com/yhtang/FunFact.git
 cd FunFact/
 python setup.py install
 ```
+
+# Autograd backends
+
+The default installation of FunFact installs the NumPy backend which only
+supports forward calculations. The NumPy backend doesn't support backpropagation
+and is not able to optimize tensor expressions for target data.
+
+In order to factorize data in a functional expression two other backends are
+supported:
+
+  * [JAX](https://jax.readthedocs.io/en/latest/) backend. Detailed 
+  installation instructions for JAX can be found [here](https://github.com/google/jax#installation). Alternatively, use:
+  ```bash
+  pip install "funfact[jax]"
+  ```
+
+  * [PyTorch](https://pytorch.org) backend. Detailed installation instruction
+  for PyTorch can be found [here](https://pytorch.org/get-started/locally/).
+  Alternatively, use:
+  ```bash
+  pip install "funfact[torch]"
+  ``` 
+
+# Extras
+
+Two other extras are with additional dependencies are supported. 
+
+ * To install all dependencies for generating FunFact documentation, use:
+  ```bash
+  pip install "funfact[docs]"
+  ``` 
+
+ * To install all dependencies for development of FunFact, use:
+  ```bash
+  pip install "funfact[devel]"
+  ``` 


### PR DESCRIPTION
Updated the `installation.md` documentation for issue #103.

However, the commands like `pip install "funfact[jax]"` do not yet work (at least for me). Let me know what you think @yhtang  