### PR TITLE
Numpy autograd error

### DIFF
--- a/funfact/backend/_numpy.py
+++ b/funfact/backend/_numpy.py
@@ -17,9 +17,27 @@ class NumPyBackend(metaclass=BackendMeta):
         return np.asarray(array, **kwargs)
 
     @classmethod
+    def to_numpy(cls, tensor):
+        return np.asarray(tensor)
+
+    @classmethod
     def seed(cls, key):
         cls._rng = np.random.default_rng(seed=key)
 
     @classmethod
     def normal(cls, mean, std, *shape, optimizable=False, dtype=np.float32):
         return cls._rng.normal(mean, std, shape)
+
+    @staticmethod
+    def loss_and_grad(loss_fn, example_model, example_target):
+        raise TypeError('NumPy backend does not support autograd and backward '
+                        'mode; use JAX or PyTorch backend instead.')
+
+    def autograd_decorator(ob):
+        return ob
+
+    class AutoGradMixin():
+        pass
+
+    def no_grad():
+        pass

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -17,10 +17,10 @@ class Loss(ABC):
             if model.shape[:-1] != target.shape:
                 raise ValueError(f'Target shape {target.shape} and '
                                  f'model shape {model.shape[:-1]} mismatch.')
-            data_axis = [i for i in range(target.ndim)]
+            data_axis = tuple(i for i in range(target.ndim))
             target = target[..., None]
         elif target.ndim == model.ndim:
-            data_axis = [i for i in range(target.ndim)]
+            data_axis = tuple(i for i in range(target.ndim))
             if model.shape != target.shape:
                 raise ValueError(f'Target shape {target.shape} and '
                                  f'model shape {model.shape} mismatch.')


### PR DESCRIPTION
The NumPy backend will now throw an informative error when `factorize` is used:

```
TypeError: NumPy backend does not support autograd and backward mode; use JAX or PyTorch backend instead.
```

All methods from the other two backends have been added to the NumPy backend as well.