### PR TITLE
Rewrite vectorizer using `broadcast_to`.

### DIFF
--- a/funfact/lang/_terminal.py
+++ b/funfact/lang/_terminal.py
@@ -165,6 +165,17 @@ class AbstractTensor(Identifiable, LaTexReprMixin):
         self.initializer = initializer
         self.optimizable = optimizable
 
+    def vectorize(self, n):
+        '''Extend dimensionality by one.'''
+        shape = (*self._shape, n)
+        if self.initializer is None or callable(self.initializer):
+            initializer = self.initializer
+        else:
+            initializer = self.initializer[..., None]
+        return type(self)(
+            *shape, initializer=initializer, optimizable=self.optimizable
+        )
+
     @property
     def shape(self):
         return self._shape

--- a/funfact/lang/interpreter/_vectorize.py
+++ b/funfact/lang/interpreter/_vectorize.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import copy
 from typing import Optional
-from funfact.util.iterable import as_tuple, flatten
 from funfact.lang._ast import Primitives as P
 from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
 from ._base import TranscribeInterpreter
@@ -40,20 +38,8 @@ class Vectorizer(TranscribeInterpreter):
         self, tensor: P.tensor, indices: P.indices, live_indices,
         keep_indices, **kwargs
     ):
-        # update indices.items w/o altering original
-        items = copy.copy(indices.items)
-        items.append(self.vec_index)
-        indices.items = items
-        # update tensor.abstract w/o altering original
-        abstract = copy.copy(tensor.abstract)
-        shape = [abstract.shape]
-        shape.append(self.replicas)
-        abstract._shape = as_tuple(flatten(shape))
-        if abstract.initializer is not None:
-            if not callable(abstract.initializer):
-                initializer = copy.copy(abstract.initializer)
-                abstract.initializer = initializer[..., None]
-        tensor.abstract = abstract
+        indices.items = (*indices.items, self.vec_index)
+        tensor.abstract = tensor.abstract.vectorize(self.replicas)
         return []
 
     @as_payload

--- a/funfact/test_vectorization.py
+++ b/funfact/test_vectorization.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+import numpy as np
+from funfact import tensor, indices, Factorization
+from .vectorization import vectorize, view
+
+
+def test_vectorize_random():
+    a = tensor('a', 2, 3)
+    b = tensor('b', 3, 4)
+    i, j, k = indices('i, j, k')
+    tsrex = a[i, j] * b[j, k]
+    nvec = 7
+    tsrex_vector = vectorize(tsrex, nvec)
+    assert tsrex_vector.ndim == tsrex.ndim + 1
+    assert tsrex_vector.shape == (*tsrex.shape, nvec)
+    assert tsrex_vector.root.lhs.tensor.abstract.shape == (*a.shape, nvec)
+    assert tsrex_vector.root.rhs.tensor.abstract.shape == (*b.shape, nvec)
+
+    fac = Factorization.from_tsrex(tsrex_vector)
+    assert fac.ndim == tsrex_vector.ndim
+    assert fac.all_factors[0].shape == (*a.shape, nvec)
+    assert fac.all_factors[1].shape == (*b.shape, nvec)
+
+
+def test_vectorize_concrete():
+    a = tensor('a', 2, 3)
+    b = tensor('b', np.eye(3))
+    i, j, k = indices('i, j, k')
+    tsrex = a[i, j] * b[j, k]
+    nvec = 7
+    tsrex_vector = vectorize(tsrex, nvec)
+    assert tsrex_vector.ndim == tsrex.ndim + 1
+    assert tsrex_vector.shape == (*tsrex.shape, nvec)
+    assert tsrex_vector.root.lhs.tensor.abstract.shape == (*a.shape, nvec)
+    assert tsrex_vector.root.rhs.tensor.abstract.shape == (*b.shape, nvec)
+
+    fac = Factorization.from_tsrex(tsrex_vector)
+    assert fac.ndim == tsrex_vector.ndim
+    assert fac.all_factors[0].shape == (*a.shape, nvec)
+    assert fac.all_factors[1].shape == (*b.shape, nvec)
+
+
+def test_view_random():
+    a = tensor('a', 2, 3)
+    b = tensor('b', 3, 4)
+    i, j, k = indices('i, j, k')
+    tsrex = a[i, j] * b[j, k]
+    nvec = 7
+    tsrex_vector = vectorize(tsrex, nvec)
+    vfac = Factorization.from_tsrex(tsrex_vector)
+    for i in range(nvec):
+        fac = view(vfac, tsrex, i)
+        assert fac.ndim == tsrex.ndim
+        assert fac.all_factors[0].shape == a.shape
+        assert fac.all_factors[1].shape == b.shape
+
+    # view last instance
+    view(vfac, tsrex, -1)
+
+    with pytest.raises(IndexError):
+        view(vfac, tsrex, nvec)
+
+
+def test_view_concrete():
+    a = tensor('a', 2, 3)
+    b = tensor('b', np.eye(3))
+    i, j, k = indices('i, j, k')
+    tsrex = a[i, j] * b[j, k]
+    nvec = 7
+    tsrex_vector = vectorize(tsrex, nvec)
+    vfac = Factorization.from_tsrex(tsrex_vector)
+    for i in range(nvec):
+        fac = view(vfac, tsrex, i)
+        assert fac.ndim == tsrex.ndim
+        assert fac.all_factors[0].shape == a.shape
+        assert fac.all_factors[1].shape == b.shape
+        assert np.allclose(fac['b'], b.root.abstract.initializer)
+
+    # view last instance
+    view(vfac, tsrex, -1)
+
+    with pytest.raises(IndexError):
+        view(vfac, tsrex, nvec)

--- a/funfact/vectorization.py
+++ b/funfact/vectorization.py
@@ -8,7 +8,7 @@ from funfact.model import Factorization
 
 
 def vectorize(tsrex, n):
-    '''Vectorize a tensor expression by extending its dimensionality by one.
+    ''''Vectorize' a tensor expression by extending its dimensionality by one.
     Each slice along the vectorization dimension of a factorization model
     represents an independent realization of the original tensor expression.
     A typical use case is multi-replica optimization.
@@ -48,11 +48,12 @@ def view(fac, tsrex_scalar, instance: int):
         Factorization:
             A factorization model.
     '''
+    if instance >= fac.shape[-1]:
+        raise IndexError(
+            f'Only {fac.shape[-1]} vector instances exist, '
+            f'index {instance} out of range.'
+        )
     fac_scalar = Factorization(tsrex_scalar)
-    for i, f in enumerate(fac.factors):
-        try:
-            fac_scalar.factors[i] = f[..., instance]
-        except IndexError:
-            # if the last dimension is a broadcasting one
-            fac_scalar.factors[i] = f[..., 0]
+    for i, f in enumerate(fac.all_factors):
+        fac_scalar.all_factors[i] = f[..., instance]
     return fac_scalar


### PR DESCRIPTION
Uses the `broadcast_to` method from the backend to simplify the vectorization of tensor expressions. This does not change any API or frontend behavior.

Also added unit tests to cover all lines in `vectorization.py`.