### PR TITLE
Make exponentiation a special case of binary operations.

### DIFF
--- a/funfact/__init__.py
+++ b/funfact/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Fun-Fact"""
 from .backend import use, active_backend, available_backends
-from .lang import index, indices, tensor, template, _0, _1, delta
+from .lang import index, indices, tensor, template, _0, _1, delta, pi
 from .lang._math import *  # noqa: F401, F403
 from .model import Factorization
 from .algorithm import factorize
@@ -21,6 +21,7 @@ __all__ = [
     '_0',
     '_1',
     'delta',
+    'pi',
     'Factorization',
     'factorize',
     'vectorize',

--- a/funfact/lang/__init__.py
+++ b/funfact/lang/__init__.py
@@ -3,7 +3,7 @@
 import warnings
 from ._tsrex import index, indices, tensor, TsrEx
 from ._tplex import template
-from ._predefined_literal import _0, _1, delta
+from ._predefined_literal import _0, _1, delta, pi
 
 
 try:
@@ -23,5 +23,13 @@ except Exception:
 
 
 __all__ = [
-    'index', 'indices', 'tensor', 'template', '_0', '_1', 'delta', 'TsrEx'
+    'index',
+    'indices',
+    'tensor',
+    'template',
+    '_0',
+    '_1',
+    'delta',
+    'pi',
+    'TsrEx'
 ]

--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -71,6 +71,10 @@ class Primitives:
         '''elementwise negation'''
 
     @primitive(precedence=5)
+    def matmul(lhs: _ASNode, rhs: _ASNode):
+        '''indexless matrix multiplication'''
+
+    @primitive(precedence=5)
     def kron(lhs: _ASNode, rhs: _ASNode):
         '''indexless Kronecker product'''
 

--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -62,10 +62,6 @@ class Primitives:
     def call(f: str, x: _ASNode):
         '''general function call: f(x)'''
 
-    @primitive(precedence=3)
-    def pow(base: _ASNode, exponent: _ASNode):
-        '''raise to power: base**exponent'''
-
     @primitive(precedence=4)
     def neg(x: _ASNode):
         '''elementwise negation'''

--- a/funfact/lang/_predefined_literal.py
+++ b/funfact/lang/_predefined_literal.py
@@ -10,3 +10,5 @@ _0 = TsrEx(P.literal(LiteralValue(0, r'\boldsymbol{0}')))
 _1 = TsrEx(P.literal(LiteralValue(1, r'\boldsymbol{1}')))
 
 delta = TsrEx(P.literal(LiteralValue('delta', r'\boldsymbol{\delta}')))
+
+pi = TsrEx(P.literal(LiteralValue(3.141592653589793238462643383279, r'\pi')))

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -234,7 +234,7 @@ class SyntaxOverloadMixin:
 
     @as_tsrex
     def __rsub__(self, lhs):
-        return _binary(_as_node(lhs), _as_node(self), 6, 'add')
+        return _binary(_as_node(lhs), _as_node(self), 6, 'subtract')
 
     @as_tsrex
     def __rmul__(self, lhs):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -221,6 +221,10 @@ class SyntaxOverloadMixin:
         return _binary(_as_node(self), _as_node(rhs), 5, 'multiply')
 
     @as_tsrex
+    def __matmul__(self, rhs):
+        return _matmul(_as_node(self), _as_node(rhs))
+
+    @as_tsrex
     def __truediv__(self, rhs):
         return _binary(_as_node(self), _as_node(rhs), 5, 'divide')
 
@@ -239,6 +243,10 @@ class SyntaxOverloadMixin:
     @as_tsrex
     def __rmul__(self, lhs):
         return _binary(_as_node(lhs), _as_node(self), 5, 'multiply')
+
+    @as_tsrex
+    def __rmatmul__(self, lhs):
+        return _matmul(_as_node(lhs), _as_node(self))
 
     @as_tsrex
     def __rtruediv__(self, lhs):
@@ -286,6 +294,11 @@ class TsrEx(
 
 
 _dispatch = Dispatcher()
+
+
+@_dispatch
+def _matmul(lhs: _ASNode, rhs: _ASNode):
+    return P.matmul(lhs, rhs)
 
 
 @_dispatch

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -230,7 +230,7 @@ class SyntaxOverloadMixin:
 
     @as_tsrex
     def __pow__(self, rhs):
-        return _pow(_as_node(self), _as_node(rhs))
+        return _binary(_as_node(self), _as_node(rhs), 3, 'float_power')
 
     @as_tsrex
     def __radd__(self, lhs):
@@ -254,7 +254,7 @@ class SyntaxOverloadMixin:
 
     @as_tsrex
     def __rpow__(self, lhs):
-        return _pow(_as_node(lhs), _as_node(self))
+        return _binary(_as_node(lhs), _as_node(self), 3, 'float_power')
 
     @as_tsrex
     def __getitem__(self, indices):
@@ -309,11 +309,6 @@ def _binary(lhs: _ASNode, rhs: _ASNode, precedence, oper):
 @_dispatch
 def _neg(node: _ASNode):
     return P.neg(node)
-
-
-@_dispatch
-def _pow(base: _ASNode, exponent: _ASNode):
-    return P.pow(base, exponent)
 
 
 @_dispatch

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -41,11 +41,15 @@ class ASCIIRenderer(TranscribeInterpreter):
 
     @as_payload
     def pow(self, base, exponent, **kwargs):
-        return 'pow'
+        return ''
 
     @as_payload
     def neg(self, x, **kwargs):
-        return '-'
+        return ''
+
+    @as_payload
+    def matmul(self, lhs, rhs, **kwargs):
+        return ''
 
     @as_payload
     def binary(self, lhs, rhs, precedence, oper, **kwargs):

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -40,10 +40,6 @@ class ASCIIRenderer(TranscribeInterpreter):
         return f
 
     @as_payload
-    def pow(self, base, exponent, **kwargs):
-        return ''
-
-    @as_payload
     def neg(self, x, **kwargs):
         return ''
 

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -70,10 +70,6 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
-    def pow(self, base: Any, exponent: Any, **payload):
-        pass
-
-    @abstractmethod
     def neg(self, x: Any, **payload):
         pass
 
@@ -173,10 +169,6 @@ class TranscribeInterpreter(ABC):
 
     @abstractmethod
     def call(self, f: str, x: P.Tensorial, **payload):
-        pass
-
-    @abstractmethod
-    def pow(self, base: P.Numeric, exponent: P.Numeric, **payload):
         pass
 
     @abstractmethod

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -78,6 +78,10 @@ class ROOFInterpreter(ABC):
         pass
 
     @abstractmethod
+    def matmul(self, lhs: Any, rhs: Any, **payload):
+        pass
+
+    @abstractmethod
     def binary(
         self, lhs: Any, rhs: Any, precedence: int, pairwise: str, **payload
     ):
@@ -177,6 +181,10 @@ class TranscribeInterpreter(ABC):
 
     @abstractmethod
     def neg(self, x: P.Numeric, **payload):
+        pass
+
+    @abstractmethod
+    def matmul(self, lhs: P.Numeric, rhs: P.Numeric, **payload):
         pass
 
     @abstractmethod

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -60,6 +60,9 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
     def neg(self, x: P.Numeric, **kwargs):
         return []
 
+    def matmul(self, lhs: P.Numeric, rhs: P.Numeric, **kwargs):
+        return []
+
     def binary(
         self, lhs: P.Numeric, rhs: P.Numeric, precedence: int, oper: str,
         **kwargs

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -52,11 +52,6 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
     def call(self, f: str, x: P.Tensorial, **kwargs):
         return []
 
-    @as_payload
-    def pow(self, base: P.Numeric, exponent: P.Numeric, **kwargs):
-        map = IndexMap()
-        return f'{map(base.live_indices)},{map(exponent.live_indices)}'
-
     def neg(self, x: P.Numeric, **kwargs):
         return []
 

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -37,6 +37,9 @@ class Evaluator(ROOFInterpreter):
     def neg(self, x, **kwargs):
         return -x
 
+    def matmul(self, lhs, rhs, **kwargs):
+        return lhs @ rhs
+
     def binary(self, lhs, rhs, precedence, oper, **kwargs):
         return getattr(ab, oper)(lhs, rhs)
 

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -31,9 +31,6 @@ class Evaluator(ROOFInterpreter):
     def call(self, f, x, **kwargs):
         return getattr(ab, f)(x)
 
-    def pow(self, base, exponent, **kwargs):
-        return ab.power(base, exponent)
-
     def neg(self, x, **kwargs):
         return -x
 

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -103,14 +103,6 @@ class IndexPropagator(TranscribeInterpreter):
         return x.live_indices, x.keep_indices, x.kron_indices
 
     @as_payload
-    def pow(self, base: P.Numeric, exponent: P.Numeric, **kwargs):
-        return (
-            base.live_indices + exponent.live_indices,
-            base.keep_indices + exponent.keep_indices,
-            base.kron_indices + exponent.kron_indices
-        )
-
-    @as_payload
     def neg(self, x: P.Numeric, **kwargs):
         return x.live_indices, x.keep_indices, x.kron_indices
 

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -115,6 +115,10 @@ class IndexPropagator(TranscribeInterpreter):
         return x.live_indices, x.keep_indices, x.kron_indices
 
     @as_payload
+    def matmul(self, lhs: P.Numeric, rhs: P.Numeric, **kwargs):
+        return [], [], []
+
+    @as_payload
     def binary(
         self, lhs: P.Numeric, rhs: P.Numeric, precedence: int, oper: str,
         **kwargs

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -51,7 +51,10 @@ class LeafInitializer(TranscribeInterpreter):
     def neg(self, x, **kwargs):
         return []
 
-    def binary(self, lhs, rhs, oper, **kwargs):
+    def matmul(self, lhs, rhs, **kwargs):
+        return []
+
+    def binary(self, lhs, rhs, precedence, oper, **kwargs):
         return []
 
     def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, **kwargs):

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -45,9 +45,6 @@ class LeafInitializer(TranscribeInterpreter):
     def call(self, f, x, **kwargs):
         return []
 
-    def pow(self, base, exponent, **kwargs):
-        return []
-
     def neg(self, x, **kwargs):
         return []
 

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -8,6 +8,7 @@ _omap = dict(
     subtract='-',
     multiply=r'\times',
     divide='/',
+    float_power='^',
     min=r'\min',
     max=r'\max',
     log_sum_exp='LSE',
@@ -51,9 +52,6 @@ class LatexRenderer(ROOFInterpreter):
     def call(self, f, x, **kwargs):
         return fr'\operatorname{{{f}}}{{{x}}}'
 
-    def pow(self, base, exponent, **kwargs):
-        return fr'{{{base}}}^{{{exponent}}}'
-
     def neg(self, x, **kwargs):
         return fr'-{x}'
 
@@ -61,7 +59,7 @@ class LatexRenderer(ROOFInterpreter):
         return fr'{lhs} {rhs}'
 
     def binary(self, lhs, rhs, precedence, oper, **kwargs):
-        return fr'{lhs} {_omap[oper]} {rhs}'
+        return fr'{{{lhs}}} {_omap[oper]} {{{rhs}}}'
 
     def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, **kwargs):
         if reduction == 'sum':

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -57,6 +57,9 @@ class LatexRenderer(ROOFInterpreter):
     def neg(self, x, **kwargs):
         return fr'-{x}'
 
+    def matmul(self, lhs, rhs, **kwargs):
+        return fr'{lhs} {rhs}'
+
     def binary(self, lhs, rhs, precedence, oper, **kwargs):
         return fr'{lhs} {_omap[oper]} {rhs}'
 

--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from typing import Optional, Tuple
+import numpy as np
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
 from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
@@ -40,13 +41,6 @@ class ShapeAnalyzer(TranscribeInterpreter):
         return x.shape
 
     @as_payload
-    def pow(self, base: P.Numeric, exponent: P.Numeric, **kwargs):
-        if base.shape:
-            return base.shape
-        else:
-            return exponent.shape
-
-    @as_payload
     def neg(self, x: P.Numeric, **kwargs):
         return x.shape
 
@@ -74,12 +68,13 @@ class ShapeAnalyzer(TranscribeInterpreter):
         self, lhs: P.Numeric, rhs: P.Numeric, precedence: int, oper: str,
         **kwargs
     ):
-        if lhs.shape != rhs.shape:
+        try:
+            return tuple(np.broadcast_shapes(lhs.shape, rhs.shape))
+        except ValueError:
             raise SyntaxError(
-                'Elementwise operations require tensors of same shape. '
+                'Binary operations require tensors of compatible shape. '
                 f'Got {lhs.shape} and {rhs.shape}.'
             )
-        return lhs.shape
 
     @as_payload
     def ein(

--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -51,11 +51,34 @@ class ShapeAnalyzer(TranscribeInterpreter):
         return x.shape
 
     @as_payload
+    def matmul(self, lhs: P.Numeric, rhs: P.Numeric, **kwargs):
+        if len(lhs.shape) != 2:
+            raise SyntaxError(
+                'Only matrices (2D tensors) supports multiplication '
+                f'using `@`. Left-hand side operand has shape {lhs.shape}.'
+            )
+        if len(rhs.shape) != 2:
+            raise SyntaxError(
+                'Only matrices (2D tensors) supports multiplication '
+                f'using `@`. Right-hand side operand has shape {rhs.shape}.'
+            )
+        if lhs.shape[1] != rhs.shape[0]:
+            raise SyntaxError(
+                f'Dimensions of matrices {lhs.shape} and {rhs.shape} '
+                'not compatible for multiplication.'
+            )
+        return (lhs.shape[0], rhs.shape[1])
+
+    @as_payload
     def binary(
         self, lhs: P.Numeric, rhs: P.Numeric, precedence: int, oper: str,
         **kwargs
     ):
-        assert lhs.shape == rhs.shape
+        if lhs.shape != rhs.shape:
+            raise SyntaxError(
+                'Elementwise operations require tensors of same shape. '
+                f'Got {lhs.shape} and {rhs.shape}.'
+            )
         return lhs.shape
 
     @as_payload

--- a/funfact/lang/interpreter/_slicing_propagation.py
+++ b/funfact/lang/interpreter/_slicing_propagation.py
@@ -48,6 +48,10 @@ class SlicingPropagator(TranscribeInterpreter):
     def neg(self, x: P.Numeric, slices, **kwargs):
         x.slices = slices
 
+    def matmul(self, lhs: P.Numeric, rhs: P.Numeric, slices, **kwargs):
+        lhs.slices = (slices[0], slice(None))
+        rhs.slices = (slice(None), slices[1])
+
     def binary(
         self, lhs: P.Numeric, rhs: P.Numeric, oper: str, slices,
         **kwargs

--- a/funfact/lang/interpreter/_slicing_propagation.py
+++ b/funfact/lang/interpreter/_slicing_propagation.py
@@ -41,10 +41,6 @@ class SlicingPropagator(TranscribeInterpreter):
     def call(self, f: str, x: P.Tensorial, slices, **kwargs):
         x.slices = slices
 
-    def pow(self, base: P.Numeric, exponent: P.Numeric, slices, **kwargs):
-        base.slices = slices
-        exponent.slices = slices
-
     def neg(self, x: P.Numeric, slices, **kwargs):
         x.slices = slices
 

--- a/funfact/lang/interpreter/_syntax_validation.py
+++ b/funfact/lang/interpreter/_syntax_validation.py
@@ -48,9 +48,6 @@ class SyntaxValidator:
     def call(self, node: _ASNode, parent: _ASNode):
         pass
 
-    def pow(self, node: _ASNode, parent: _ASNode):
-        pass
-
     def neg(self, node: _ASNode, parent: _ASNode):
         pass
 

--- a/funfact/lang/interpreter/_vectorize.py
+++ b/funfact/lang/interpreter/_vectorize.py
@@ -48,7 +48,13 @@ class Vectorizer(TranscribeInterpreter):
             keep_indices, **kwargs):
         return []
 
-    def binary(self, lhs: P.Numeric, rhs: P.Numeric, oper: str, **kwargs):
+    def matmul(self, lhs: P.Numeric, rhs: P.Numeric, **kwargs):
+        return []
+
+    def binary(
+        self, lhs: P.Numeric, rhs: P.Numeric, precedence: int, oper: str,
+        **kwargs
+    ):
         return []
 
     @as_payload('outidx')

--- a/funfact/lang/interpreter/_vectorize.py
+++ b/funfact/lang/interpreter/_vectorize.py
@@ -40,10 +40,6 @@ class Vectorizer(TranscribeInterpreter):
              keep_indices, **kwargs):
         return []
 
-    def pow(self, base: P.Numeric, exponent: P.Numeric, live_indices,
-            keep_indices, **kwargs):
-        return []
-
     def neg(self, x: P.Numeric, live_indices,
             keep_indices, **kwargs):
         return []


### PR DESCRIPTION
Also fixes a bug that unnecessarily excludes tensors of broadcastable shapes to act on each other in binary operations.

``` py
a = ff.tensor('a', 2, 3)
b = ff.tensor('b', 2, 3)
fac = ff.Factorization.from_tsrex(a**b)
print(fac())
print(fac.tsrex.asciitree)
fac.tsrex
```
Output:
```
[[      nan 0.6022982 1.4585489]
 [      nan       nan       nan]]
 binary: float_power 
 ├── tensor: a 
 ╰── tensor: b 
```