### PR TITLE
Support for dtype

### DIFF
--- a/funfact/algorithm.py
+++ b/funfact/algorithm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import numpy as np
-import operator
 import tqdm
 import funfact.optim
 import funfact.loss
@@ -74,10 +73,10 @@ def factorize(
     '''
 
     if dtype is None:
-        dtype = str(target.dtype)
-        dtype = operator.attrgetter(dtype)(ab)
-
-    target = ab.tensor(target, dtype=dtype)
+        target = ab.tensor(target)
+        dtype = target.dtype
+    else:
+        target = ab.tensor(target, dtype=dtype)
 
     @ab.autograd_decorator
     class _Factorization(Factorization, ab.AutoGradMixin):

--- a/funfact/algorithm.py
+++ b/funfact/algorithm.py
@@ -13,7 +13,7 @@ from funfact.vectorization import vectorize, view
 def factorize(
     tsrex, target, lr=0.1, tol=1e-6, max_steps=10000, optimizer='Adam',
     loss='mse_loss', nvec=1, stop_by='first', returns='best',
-    checkpoint_freq=50, dtype='target', **kwargs
+    checkpoint_freq=50, dtype=None, **kwargs
 ):
     '''Factorize a target tensor using the given tensor expression. The
     solution is found by minimizing the loss function between the original and
@@ -57,9 +57,9 @@ def factorize(
 
         checkpoint_freq (int >= 1): The frequency of convergence checking.
 
-        dtype: The datatype of the factorization model ('target', ab.dtype):
+        dtype: The datatype of the factorization model (None, ab.dtype):
 
-            - If 'target', the same data type as the target tensor is used.
+            - If None, the same data type as the target tensor is used.
             - If concrete dtype (float32, float64, complex64, complex128),
             that data type is used.
 
@@ -73,7 +73,7 @@ def factorize(
             that represents all the solutions.
     '''
 
-    if dtype == 'target':
+    if dtype is None:
         dtype = str(target.dtype)
         dtype = operator.attrgetter(dtype)(ab)
 

--- a/funfact/backend/__init__.py
+++ b/funfact/backend/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
 import sys
 import importlib
 
@@ -18,11 +19,11 @@ available_backends = {
 Examples:
     >>> from funfact import available_backends
     >>> available_backends.keys()
-    dict_keys(['numpy', 'jax', 'torch'])
+    dict_keys(['jax', 'torch', 'numpy'])
 '''
 
 
-def use(backend: str):
+def use(backend: str, enable_x64: bool = False):
     '''Specify the numerical tensor algebra library to use as the computational
     backend.
 
@@ -38,6 +39,9 @@ def use(backend: str):
             Dynamic switching betwewen backends is allowed. However, tensors
             created by the previous backend will not be automatically ported to
             the new backend.
+        
+        enable_x64 (bool):
+            Enable 64bit floating point type for JAX backend.
 
     Examples:
         >>> from funfact import use, active_backend as ab
@@ -55,6 +59,8 @@ def use(backend: str):
     '''
     global _active_backend
     try:
+        if enable_x64 and backend == 'jax':
+            os.environ['JAX_ENABLE_X64'] = 'True'
         clsname = available_backends[backend]
         _active_backend = getattr(
             importlib.import_module(f'funfact.backend._{backend}'), clsname

--- a/funfact/backend/__init__.py
+++ b/funfact/backend/__init__.py
@@ -39,7 +39,7 @@ def use(backend: str, enable_x64: bool = False):
             Dynamic switching betwewen backends is allowed. However, tensors
             created by the previous backend will not be automatically ported to
             the new backend.
-        
+
         enable_x64 (bool):
             Enable 64bit floating point type for JAX backend.
 

--- a/funfact/backend/__init__.py
+++ b/funfact/backend/__init__.py
@@ -59,8 +59,8 @@ def use(backend: str, enable_x64: bool = False):
     '''
     global _active_backend
     try:
-        if enable_x64 and backend == 'jax':
-            os.environ['JAX_ENABLE_X64'] = 'True'
+        if backend == 'jax':
+            os.environ['JAX_ENABLE_X64'] = 'True' if enable_x64 else 'False'
         clsname = available_backends[backend]
         _active_backend = getattr(
             importlib.import_module(f'funfact.backend._{backend}'), clsname

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import contextlib
+import warnings
 import numpy as np
 import jax.numpy as jnp
 import jax.random as jrn
@@ -11,6 +12,17 @@ from ._meta import BackendMeta
 
 
 class JAXBackend(metaclass=BackendMeta):
+
+    if (os.getenv('JAX_ENABLE_X64') == 'True') and \
+       (not jax.config.FLAGS.jax_enable_x64):
+        warnings.warn_explicit('JAX was previously loaded without X64 enabled,'
+                               ' restart kernel to enable X64.', Warning,
+                               'WARNING', 0)
+    elif (os.getenv('JAX_ENABLE_X64') == 'False') and \
+         (jax.config.FLAGS.jax_enable_x64):
+        warnings.warn_explicit('JAX was previously loaded with X64 enabled,'
+                               ' restart kernel to disable X64.', Warning,
+                               'WARNING', 0)
 
     _nla = jnp
     _key = jrn.PRNGKey(int.from_bytes(os.urandom(7), 'big'))

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -23,8 +23,8 @@ class JAXBackend(metaclass=BackendMeta):
         return jnp.asarray(array, **kwargs)
 
     @classmethod
-    def to_numpy(cls, tensor):
-        return np.asarray(tensor)
+    def to_numpy(cls, tensor, **kwargs):
+        return np.asarray(tensor, **kwargs)
 
     @classmethod
     def seed(cls, key):

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import os
 import contextlib
-import warnings
 import numpy as np
 import jax.numpy as jnp
 import jax.random as jrn
@@ -12,17 +11,6 @@ from ._meta import BackendMeta
 
 
 class JAXBackend(metaclass=BackendMeta):
-
-    if (os.getenv('JAX_ENABLE_X64') == 'True') and \
-       (not jax.config.FLAGS.jax_enable_x64):
-        warnings.warn_explicit('JAX was previously loaded without X64 enabled,'
-                               ' restart kernel to enable X64.', Warning,
-                               'WARNING', 0)
-    elif (os.getenv('JAX_ENABLE_X64') == 'False') and \
-         (jax.config.FLAGS.jax_enable_x64):
-        warnings.warn_explicit('JAX was previously loaded with X64 enabled,'
-                               ' restart kernel to disable X64.', Warning,
-                               'WARNING', 0)
 
     _nla = jnp
     _key = jrn.PRNGKey(int.from_bytes(os.urandom(7), 'big'))

--- a/funfact/backend/_meta.py
+++ b/funfact/backend/_meta.py
@@ -6,10 +6,12 @@ from abc import ABCMeta
 class BackendMeta(ABCMeta):
 
     _required_properties = [
-        'native_t',  # tensor type native to the backend
-        'tensor_t',  # tensor type interoperable with the backend
-        'float32',   # single-precision floats
-        'float64',   # double-precision floats
+        'native_t',   # tensor type native to the backend
+        'tensor_t',   # tensor type interoperable with the backend
+        'float32',    # single-precision floats
+        'float64',    # double-precision floats
+        'complex64',  # single-precision complex floats
+        'complex128'  # double-precision complex floats
     ]
 
     _required_methods = [

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -22,9 +22,8 @@ class PyTorchBackend(metaclass=BackendMeta):
     @classmethod
     def to_numpy(cls, tensor, **kwargs):
         if tensor.requires_grad:
-            return np.asarray(tensor.detach().numpy(), **kwargs)
-        else:
-            return np.asarray(tensor.numpy(), **kwargs)
+            tensor = tensor.detach()
+        return np.asarray(tensor.numpy(), **kwargs)
 
     @classmethod
     def seed(cls, key):

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -20,11 +20,11 @@ class PyTorchBackend(metaclass=BackendMeta):
         return torch.tensor(array, requires_grad=optimizable, **kwargs)
 
     @classmethod
-    def to_numpy(cls, tensor):
+    def to_numpy(cls, tensor, **kwargs):
         if tensor.requires_grad:
-            return tensor.detach().numpy()
+            return np.asarray(tensor.detach().numpy(), **kwargs)
         else:
-            return tensor.numpy()
+            return np.asarray(tensor.numpy(), **kwargs)
 
     @classmethod
     def seed(cls, key):

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -9,7 +9,8 @@ class LeafInitializer(TranscribeInterpreter):
 
     _traversal_order = TranscribeInterpreter.TraversalOrder.POST
 
-    def __init__(self):
+    def __init__(self, dtype):
+        self.dtype = dtype
         super().__init__()
 
     def literal(self, value, **kwargs):
@@ -26,12 +27,14 @@ class LeafInitializer(TranscribeInterpreter):
                 # Otherwise, slices can share a view into the original tensor.
                 f = ab.tile if optimizable else ab.broadcast_to
                 return ab.tensor(
-                    f(initializer, shape), optimizable=optimizable
+                    f(initializer, shape), optimizable=optimizable,
+                    dtype=self.dtype
                 )
             else:
-                return initializer(shape)
+                return initializer(shape, dtype=self.dtype)
         else:
-            return ab.normal(0.0, 1.0, *shape, optimizable=optimizable)
+            return ab.normal(0.0, 1.0, *shape, optimizable=optimizable,
+                             dtype=self.dtype)
 
     def index(self, item, bound, kron, **kwargs):
         return []

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -10,6 +10,8 @@ class LeafInitializer(TranscribeInterpreter):
     _traversal_order = TranscribeInterpreter.TraversalOrder.POST
 
     def __init__(self, dtype):
+        if dtype is None:
+            dtype = ab.float32
         self.dtype = dtype
         super().__init__()
 

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -45,7 +45,7 @@ class Loss(ABC):
 class MSE(Loss):
 
     def _loss(self, model, target):
-        return ab.square(ab.subtract(model, target))
+        return ab.square(ab.abs(ab.subtract(model, target)))
 
 
 class L1(Loss):

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -45,6 +45,7 @@ class Loss(ABC):
 class MSE(Loss):
 
     def _loss(self, model, target):
+        # absolute value is for compatibility with complex data
         return ab.square(ab.abs(ab.subtract(model, target)))
 
 

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -42,12 +42,12 @@ class Factorization:
         self.__dict__.update(**extra_attributes)
 
     @classmethod
-    def from_tsrex(cls, tsrex, dtype, initialize=True):
+    def from_tsrex(cls, tsrex, dtype=None, initialize=True):
         '''Construct a factorization model from a tensor expresson.
 
         Args:
             tsrex (TsrEx): The tensor expression.
-            dtype: data type.
+            dtype: numerical data type, defaults to float32.
             initialize (bool):
                 Whether or not to fill abstract tensors with actual data.
         '''

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -42,16 +42,17 @@ class Factorization:
         self.__dict__.update(**extra_attributes)
 
     @classmethod
-    def from_tsrex(cls, tsrex, initialize=True):
+    def from_tsrex(cls, tsrex, dtype, initialize=True):
         '''Construct a factorization model from a tensor expresson.
 
         Args:
             tsrex (TsrEx): The tensor expression.
+            dtype: data type.
             initialize (bool):
                 Whether or not to fill abstract tensors with actual data.
         '''
         if initialize:
-            tsrex = tsrex | LeafInitializer()
+            tsrex = tsrex | LeafInitializer(dtype)
         return cls(tsrex)
 
     @property


### PR DESCRIPTION
Bugfix for #84.

Example code for complex optimization:

```python
import funfact as ff
import numpy as np
ff.use('torch')
m = np.random.rand(4,2,2)
m = m[..., 0] + 1j * m[..., 1]
n = np.random.rand(2,3,2)
n = n[..., 0] + 1j * n[..., 1]
target = m @ n
a = ff.tensor(4,2)
b = ff.tensor(2,3)
i,j,k = ff.indices(3)
tsrex = a[i,j] * b[j,k]
fac = ff.factorize(tsrex, target, nvec=64, max_steps=10000, dtype='target')
```