### PR TITLE
Initializers

### DIFF
--- a/docs/api/initializers.md
+++ b/docs/api/initializers.md
@@ -1,0 +1,1 @@
+::: funfact.initializers

--- a/funfact/__init__.py
+++ b/funfact/__init__.py
@@ -8,6 +8,7 @@ from .model import Factorization
 from .algorithm import factorize
 from .vectorization import vectorize, view
 from .context import is_grad_on, enable_grad
+from . import initializers
 
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     'view',
     'is_grad_on',
     'enable_grad',
+    'initializers'
 ]
 
 

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -38,7 +38,7 @@ class JAXBackend(metaclass=BackendMeta):
     @classmethod
     def uniform(cls, low, high, shape, dtype=jnp.float32):
         cls._key, subkey = jrn.split(cls._key)
-        return jrn.normal(subkey, shape, dtype, minval=low, maxval=high)
+        return jrn.uniform(subkey, shape, dtype, minval=low, maxval=high)
 
     @staticmethod
     def loss_and_grad(loss_fn, example_model, example_target):

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -35,6 +35,11 @@ class JAXBackend(metaclass=BackendMeta):
         cls._key, subkey = jrn.split(cls._key)
         return mean + std * jrn.normal(subkey, shape, dtype)
 
+    @classmethod
+    def uniform(cls, low, high, shape, dtype=jnp.float32):
+        cls._key, subkey = jrn.split(cls._key)
+        return jrn.normal(subkey, shape, dtype, minval=low, maxval=high)
+
     @staticmethod
     def loss_and_grad(loss_fn, example_model, example_target):
         loss_and_grad_fn = jax.jit(

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -31,7 +31,7 @@ class JAXBackend(metaclass=BackendMeta):
         cls._key = jrn.PRNGKey(key)
 
     @classmethod
-    def normal(cls, mean, std, *shape, optimizable=True, dtype=jnp.float32):
+    def normal(cls, mean, std, shape, dtype=jnp.float32):
         cls._key, subkey = jrn.split(cls._key)
         return mean + std * jrn.normal(subkey, shape, dtype)
 
@@ -63,3 +63,7 @@ class JAXBackend(metaclass=BackendMeta):
 
     def no_grad():
         return contextlib.nullcontext()
+
+    @classmethod
+    def set_optimizable(self, x: native_t, optimizable: bool):
+        return x

--- a/funfact/backend/_numpy.py
+++ b/funfact/backend/_numpy.py
@@ -28,6 +28,10 @@ class NumPyBackend(metaclass=BackendMeta):
     def normal(cls, mean, std, shape, dtype=np.float32):
         return cls._rng.normal(mean, std, shape)
 
+    @classmethod
+    def uniform(cls, low, high, shape, dtype=np.float32):
+        return cls._rng.uniform(low, high, shape)
+
     @staticmethod
     def loss_and_grad(loss_fn, example_model, example_target):
         raise TypeError('NumPy backend does not support autograd and backward '

--- a/funfact/backend/_numpy.py
+++ b/funfact/backend/_numpy.py
@@ -25,7 +25,7 @@ class NumPyBackend(metaclass=BackendMeta):
         cls._rng = np.random.default_rng(seed=key)
 
     @classmethod
-    def normal(cls, mean, std, *shape, optimizable=False, dtype=np.float32):
+    def normal(cls, mean, std, shape, dtype=np.float32):
         return cls._rng.normal(mean, std, shape)
 
     @staticmethod
@@ -41,3 +41,7 @@ class NumPyBackend(metaclass=BackendMeta):
 
     def no_grad():
         pass
+
+    @classmethod
+    def set_optimizable(cls, x: native_t, optimizable: bool):
+        return x

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -39,6 +39,13 @@ class PyTorchBackend(metaclass=BackendMeta):
             )
 
     @classmethod
+    def uniform(cls, low, high, shape, dtype=torch.float32):
+        with torch.no_grad():
+            return torch.rand(
+                *shape, dtype=dtype, generator=cls._gen
+            ) * (high - low) + low
+
+    @classmethod
     def transpose(cls, a, axes):
         '''torch equivalent is torch.permute'''
         return torch.permute(a, (*axes,))

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -16,8 +16,10 @@ class PyTorchBackend(metaclass=BackendMeta):
     @classmethod
     def tensor(cls, array, optimizable=False, **kwargs):
         if type(array) is cls.native_t:
-            return array.clone().detach().requires_grad_(optimizable)
-        return torch.tensor(array, requires_grad=optimizable, **kwargs)
+            t = array.clone().detach()
+        else:
+            t = torch.tensor(array, **kwargs)
+        return cls.set_optimizable(t, optimizable)
 
     @classmethod
     def to_numpy(cls, tensor, **kwargs):
@@ -30,12 +32,11 @@ class PyTorchBackend(metaclass=BackendMeta):
         cls._gen.manual_seed(key)
 
     @classmethod
-    def normal(cls, mean, std, *shape, optimizable=True, dtype=torch.float32):
-        data = torch.normal(mean, std, shape, dtype=dtype, generator=cls._gen)
-        if optimizable:
-            return data.clone().detach().requires_grad_(True)
-        else:
-            return data
+    def normal(cls, mean, std, shape, dtype=torch.float32):
+        with torch.no_grad():
+            return torch.normal(
+                mean, std, shape, dtype=dtype, generator=cls._gen
+            )
 
     @classmethod
     def transpose(cls, a, axes):
@@ -74,3 +75,7 @@ class PyTorchBackend(metaclass=BackendMeta):
         def __iter__(self):
             for f in self.factors:
                 yield f
+
+    @classmethod
+    def set_optimizable(self, x: native_t, optimizable: bool):
+        return x.requires_grad_(optimizable)

--- a/funfact/backend/test_backend.py
+++ b/funfact/backend/test_backend.py
@@ -11,8 +11,8 @@ from . import (
 )
 
 
-def test_import():
-    assert _active_backend is None
+# def test_import():
+#     assert _active_backend is None
 
 
 def test_available_backends():

--- a/funfact/initializers.py
+++ b/funfact/initializers.py
@@ -1,31 +1,113 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from abc import ABC, abstractmethod
+from numbers import Number
 from funfact import active_backend as ab
 
 
-def zeros(shape, dtype=None, optimizable=True):
-    return ab.set_optimizable(
-        ab.zeros(shape, dtype=dtype or ab.float32),
-        optimizable
-    )
+class _Initializer(ABC):
+
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return type(self)(*args, **kwargs)
+
+    @abstractmethod
+    def init(self, *args, **kwargs):
+        pass
 
 
-def ones(shape, dtype=None, optimizable=True):
-    return ab.set_optimizable(
-        ab.ones(shape, dtype=dtype or ab.float32),
-        optimizable
-    )
+class Zeros(_Initializer):
+
+    def __init__(self, dtype=None):
+        self.dtype = dtype or ab.float32
+
+    def init(self, shape):
+        return ab.zeros(shape, self.dtype)
 
 
-def normal(shape, dtype=None, optimizable=True):
-    return ab.set_optimizable(
-        ab.normal(0.0, 1.0, shape, dtype=dtype or ab.float32),
-        optimizable
-    )
+class Ones(_Initializer):
+
+    def __init__(self, dtype=None):
+        self.dtype = dtype or ab.float32
+
+    def init(self, shape):
+        ab.ones(shape, self.dtype)
 
 
-def decanormal(shape, dtype=None, optimizable=True):
-    return ab.set_optimizable(
-        ab.normal(0.0, 0.1, shape, dtype=dtype or ab.float32),
-        optimizable
-    )
+class Normal(_Initializer):
+
+    def __init__(self, std=0.01, truncation=False, dtype=None):
+        self.std = std
+        self.dtype = dtype or ab.float32
+        if truncation is True:
+            self.truncation = 2.0 * std
+        elif isinstance(truncation, Number):
+            self.truncation = float(truncation) * std
+        else:
+            self.truncation = 0
+
+    def init(self, shape):
+        n = ab.normal(0.0, self.std, shape, dtype=self.dtype)
+        if self.truncation:
+            n = ab.maximum(-self.truncation, ab.minimun(self.truncation, n))
+        return n
+
+
+class Uniform(_Initializer):
+
+    def __init__(self, scale=0.01, dtype=None):
+        self.scale = scale
+        self.dtype = dtype or ab.float32
+
+    def init(self, shape):
+        return self.scale * ab.uniform(shape, dtype=self.dtype)
+
+
+class VarianceScaling(_Initializer):
+
+    def __init__(
+        self, mode, scale=0.01, distribution='normal', in_axis=-2, out_axis=-1,
+        dtype=None
+    ):
+        assert mode in ['fan_in', 'fan_out', 'fan_avg']
+        self.mode = mode
+        self.scale = scale
+        self.in_axis = in_axis
+        self.out_axis = out_axis
+        self.dtype = dtype or ab.float32
+        if distribution == 'normal':
+            self.distribution = Normal(
+                1.0, truncation=False, dtype=dtype
+            )
+        elif distribution == 'truncated':
+            self.distribution = Normal(
+                1.0, truncation=2, dtype=dtype
+            )
+        elif distribution == 'uniform':
+            self.distribution = Uniform(
+                1.0, dtype=dtype
+            )
+        else:
+            raise ValueError(f'Invalid distribution: {distribution}.')
+
+    def init(self, shape):
+        if self.mode == 'fan_out':
+            std = (self.scale / shape[self.out_axis])**0.5
+        elif self.mode == 'fan_in':
+            std = (self.scale / shape[self.in_axis])**0.5
+        elif self.mode == 'fan_avg':
+            std = (
+                self.scale / (0.5 * (shape[self.out_axis] + shape[self.in_axis]))
+            )**0.5
+
+        return std * self.distribution.init(shape)
+
+
+zeros = Zeros()
+ones = Ones()
+normal = Normal()
+uniform = Uniform()
+variance_scaling = VarianceScaling('fan_avg')

--- a/funfact/initializers.py
+++ b/funfact/initializers.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from funfact import active_backend as ab
+
+
+def zeros(shape, dtype=None, optimizable=True):
+    return ab.set_optimizable(
+        ab.zeros(shape, dtype=dtype or ab.float32),
+        optimizable
+    )
+
+
+def ones(shape, dtype=None, optimizable=True):
+    return ab.set_optimizable(
+        ab.ones(shape, dtype=dtype or ab.float32),
+        optimizable
+    )
+
+
+def normal(shape, dtype=None, optimizable=True):
+    return ab.set_optimizable(
+        ab.normal(0.0, 1.0, shape, dtype=dtype or ab.float32),
+        optimizable
+    )
+
+
+def decanormal(shape, dtype=None, optimizable=True):
+    return ab.set_optimizable(
+        ab.normal(0.0, 0.1, shape, dtype=dtype or ab.float32),
+        optimizable
+    )

--- a/funfact/initializers.py
+++ b/funfact/initializers.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from numbers import Number
 from funfact import active_backend as ab
 from funfact.util.iterable import as_tuple
 

--- a/funfact/initializers.py
+++ b/funfact/initializers.py
@@ -1,25 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from abc import ABC, abstractmethod
 from numbers import Number
 from funfact import active_backend as ab
 
 
-class _Initializer(ABC):
-
-    @abstractmethod
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __call__(self, *args, **kwargs):
-        return type(self)(*args, **kwargs)
-
-    @abstractmethod
-    def init(self, *args, **kwargs):
-        pass
-
-
-class Zeros(_Initializer):
+class Zeros:
     '''Set all elements to 0.
 
     Args:
@@ -29,11 +14,11 @@ class Zeros(_Initializer):
     def __init__(self, dtype=None):
         self.dtype = dtype or ab.float32
 
-    def init(self, shape):
+    def __call__(self, shape):
         return ab.zeros(shape, self.dtype)
 
 
-class Ones(_Initializer):
+class Ones:
     '''Set all elements to 1.
 
     Args:
@@ -43,11 +28,11 @@ class Ones(_Initializer):
     def __init__(self, dtype=None):
         self.dtype = dtype or ab.float32
 
-    def init(self, shape):
+    def __call__(self, shape):
         ab.ones(shape, self.dtype)
 
 
-class Normal(_Initializer):
+class Normal:
     '''Sample elements from i.i.d. normal distributions.
 
     Args:
@@ -72,14 +57,14 @@ class Normal(_Initializer):
         else:
             self.truncation = 0
 
-    def init(self, shape):
+    def __call__(self, shape):
         n = ab.normal(0.0, self.std, shape, dtype=self.dtype)
         if self.truncation:
             n = ab.maximum(-self.truncation, ab.minimun(self.truncation, n))
         return n
 
 
-class Uniform(_Initializer):
+class Uniform:
     '''Sample elements from the uniform distributions.
 
     Args:
@@ -91,11 +76,11 @@ class Uniform(_Initializer):
         self.scale = scale
         self.dtype = dtype or ab.float32
 
-    def init(self, shape):
+    def __call__(self, shape):
         return self.scale * ab.uniform(shape, dtype=self.dtype)
 
 
-class VarianceScaling(_Initializer):
+class VarianceScaling:
     '''Initializes with adaptive scale according to the shape.
 
     Args:
@@ -138,13 +123,6 @@ class VarianceScaling(_Initializer):
         else:
             raise ValueError(f'Invalid distribution: {distribution}.')
 
-    def init(self, shape):
+    def __call__(self, shape):
         std = (self.scale / shape[self.axis])**0.5
         return std * self.distribution.init(shape)
-
-
-zeros = Zeros()
-ones = Ones()
-normal = Normal()
-uniform = Uniform()
-variance_scaling = VarianceScaling()

--- a/funfact/initializers.py
+++ b/funfact/initializers.py
@@ -125,4 +125,4 @@ class VarianceScaling:
 
     def __call__(self, shape):
         std = (self.scale / shape[self.axis])**0.5
-        return std * self.distribution.init(shape)
+        return std * self.distribution(shape)

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from funfact.backend import active_backend as ab
+from funfact.initializers import normal
 from ._base import TranscribeInterpreter
 
 
@@ -33,10 +34,9 @@ class LeafInitializer(TranscribeInterpreter):
                     dtype=self.dtype
                 )
             else:
-                return initializer(shape, dtype=self.dtype)
+                return ab.set_optimizable(initializer(shape), optimizable)
         else:
-            return ab.normal(0.0, 1.0, *shape, optimizable=optimizable,
-                             dtype=self.dtype)
+            return normal(shape, optimizable=optimizable)
 
     def index(self, item, bound, kron, **kwargs):
         return []

--- a/funfact/lang/interpreter/test_einop.py
+++ b/funfact/lang/interpreter/test_einop.py
@@ -14,31 +14,31 @@ def test_einop():
     tol = 20 * np.finfo(np.float32).eps
 
     # right elementwise multiplication
-    lhs = ab.normal(0.0, 1.0, 3, 2)
-    rhs = ab.normal(0.0, 1.0, 1)
+    lhs = ab.normal(0.0, 1.0, (3, 2))
+    rhs = ab.normal(0.0, 1.0, (1,))
     spec = 'ab,->ab|'
     res = _einop(spec, lhs, rhs, 'sum', 'multiply')
     assert(res.shape == lhs.shape)
     assert pytest.approx(np.ravel(res), tol) == np.ravel(lhs * rhs)
 
     # left elementwise multiplication
-    lhs = ab.normal(0.0, 1.0, 1)
-    rhs = ab.normal(0.0, 1.0, 3, 2)
+    lhs = ab.normal(0.0, 1.0, (1,))
+    rhs = ab.normal(0.0, 1.0, (3, 2))
     spec = ',ab->ab|'
     res = _einop(spec, lhs, rhs, 'sum', 'multiply')
     assert(res.shape == rhs.shape)
     assert pytest.approx(np.ravel(res), tol) == np.ravel(lhs * rhs)
 
     # scalar multiplication
-    lhs = ab.normal(0.0, 1.0, 1)
-    rhs = ab.normal(0.0, 1.0, 1)
+    lhs = ab.normal(0.0, 1.0, (1,))
+    rhs = ab.normal(0.0, 1.0, (1,))
     spec = ',->|'
     res = _einop(spec, lhs, rhs, 'sum', 'multiply')
     assert pytest.approx(np.ravel(res), tol) == np.ravel(lhs * rhs)
 
     # matrix elementwise multiplication
-    lhs = ab.normal(0.0, 1.0, 3, 2)
-    rhs = ab.normal(0.0, 1.0, 3, 2)
+    lhs = ab.normal(0.0, 1.0, (3, 2))
+    rhs = ab.normal(0.0, 1.0, (3, 2))
     spec = 'ab,ab->ab|'
     res = _einop(spec, lhs, rhs, 'sum', 'multiply')
     assert(res.shape == lhs.shape)

--- a/funfact/test_initializers.py
+++ b/funfact/test_initializers.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+from .initializers import (
+    Ones,
+    Zeros,
+    Normal,
+    Uniform,
+    VarianceScaling
+)
+
+
+@pytest.mark.parametrize('init', [
+    Ones,
+    Zeros,
+    Normal,
+    Uniform,
+    VarianceScaling
+])
+def test_generic(init):
+    initializer = init()
+    tensor = initializer((2, 3, 4))
+    assert tensor.shape == (2, 3, 4)
+
+    tensor = initializer((10,))
+    assert tensor.shape == (10,)
+
+    tensor = initializer(10)
+    assert tensor.shape == (10,)
+
+    if init is VarianceScaling:
+        with pytest.raises(IndexError):
+            initializer(())
+    else:
+        tensor = initializer(())
+        assert tensor.shape == ()
+
+
+def test_ones():
+    initializer = Ones()
+    for n in initializer(100):
+        assert n == 1.0
+
+
+def test_zeros():
+    initializer = Zeros()
+    for n in initializer(100):
+        assert n == 0.0
+
+
+def test_normal():
+    initializer = Normal(std=1.0)
+    with pytest.raises(AssertionError):
+        t = initializer(1000)
+        assert t.min() >= -2.0 and t.max() <= 2.0
+
+    initializer = Normal(std=1.0, truncation=True)
+    t = initializer(1000)
+    assert t.min() >= -2.0 and t.max() <= 2.0
+
+    initializer = Normal(std=1.0, truncation=1.0)
+    t = initializer(1000)
+    assert t.min() >= -1.0 and t.max() <= 1.0
+
+
+def test_variance_scaling():
+    for distribution in ['uniform', 'normal', 'truncated']:
+        initializer = VarianceScaling(distribution=distribution)
+        tensor = initializer(1000)
+        assert tensor.shape == (1000,)
+
+    with pytest.raises(ValueError):
+        initializer = VarianceScaling(distribution='nonexisting-distribution')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,7 @@ plugins:
             show_root_full_path: False
             # show_signature_annotations: True
             # show_root_members_full_path: True
-            members_order: source
+            members_order: "source"
             heading_level: 1
             # show_root_toc_entry: True
 nav:
@@ -68,6 +68,7 @@ nav:
         - "funfact.tensor": api/tensor.md
         - "funfact.index": api/index.md
         - "funfact.indices": api/indices.md
+        - "funfact.initializers": api/initializers.md
         - "funfact.TsrEx": api/tsrex.md
         - "funfact.Factorization": api/factorization.md
         - "funfact.factorize": api/factorize.md


### PR DESCRIPTION
Implemented a number of common initialization distributions in `funfact.initializers`.

Each initializer can be either used as-is, or with arguments to tweak the actual distribution being used.

Example usage:
``` py
n, m = img.shape
u = ff.tensor('u', n, r, initializer=ff.initializers.Normal)  # use as-is
v = ff.tensor('v', m, r, initializer=ff.initializers.Normal(dtype=ab.float64))  # override data type
a = ff.tensor('a', r, initializer=ff.initializers.VarianceScaling(np.var(img), axis=0))  # additional config
b = ff.tensor('b')
i, j, k = ff.indices('i, j, k')
rbfex = ff.exp(-(u[i, ~k] - v[j, ~k])**2) * a[k] + b[[]]
rbfex
```