### PR TITLE
conjugate(grad) for JAX

### DIFF
--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -45,7 +45,7 @@ class JAXBackend(metaclass=BackendMeta):
 
         def wrapper(model, target):
             loss, dmodel = loss_and_grad_fn(model, target)
-            return loss, dmodel.factors
+            return loss, [jnp.conjugate(df) for df in dmodel.factors]
         return wrapper
 
     def autograd_decorator(*args, **kwargs):


### PR DESCRIPTION
JAX returns the complex conjugate of the gradient by default. This PR fixes the JAX backend to return the true complex gradient.