### PR TITLE
[WIP] Ellipsis support in index notations

### DIFF
--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -4,7 +4,12 @@ from dataclasses import make_dataclass
 import inspect
 from numbers import Real
 from typing import Optional, Union, Tuple
-from ._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from ._terminal import (
+    AbstractIndex,
+    AbstractEllipsis,
+    AbstractTensor,
+    LiteralValue
+)
 
 
 class _ASNode:
@@ -42,6 +47,14 @@ class Primitives:
     def tensor(abstract: AbstractTensor):
         '''an abstract tensor'''
 
+    #@primitive(precedence=0)
+    #def ellipsis(ellipsis: AbstractEllipsis):
+    #    '''an ellipsis for indexing tensors.'''
+    
+    @primitive(precedence=0)
+    def ellipsis():
+        '''an ellipsis for indexing tensors.'''
+
     @primitive(precedence=0)
     def index(item: AbstractIndex, bound: bool, kron: bool):
         '''an index; bound indices are not reduced even if they appear twice;
@@ -49,7 +62,7 @@ class Primitives:
         same index.'''
 
     @primitive(precedence=0)
-    def indices(items: Tuple[AbstractIndex]):
+    def indices(items: Tuple[index, ellipsis]):
         '''a tuple of indices'''
 
     @primitive(precedence=1)

--- a/funfact/lang/_terminal.py
+++ b/funfact/lang/_terminal.py
@@ -131,6 +131,22 @@ class AbstractIndex(Identifiable, LaTexReprMixin):
             return fr'{{{letter}}}'
 
 
+class AbstractEllipsis(Identifiable, LaTexReprMixin):
+    _uuid = uuid.uuid4()
+
+    def __init__(self, symbol: str = None):
+        self.uuid = self._uuid
+
+    def __str__(self):
+        return '...'
+
+    def __repr__(self) -> str:
+        return '...'
+
+    def _repr_tex_(self):
+        return r'{{\ldots}}'
+
+
 class AbstractTensor(Identifiable, LaTexReprMixin):
     '''An abstract tensor is a symbolic representation of a multidimensional
     array and is convenient for specifying **tensor expressions**. At

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -17,7 +17,12 @@ from .interpreter import (
     ShapeAnalyzer,
     EinsteinSpecGenerator
 )
-from ._terminal import LiteralValue, AbstractIndex, AbstractTensor
+from ._terminal import (
+    LiteralValue,
+    AbstractIndex,
+    AbstractEllipsis,
+    AbstractTensor
+)
 
 
 class ASCIITreeFactory:
@@ -345,16 +350,10 @@ def _getitem(node: _ASNode, indices):  # noqa: F811
     #                         'Indices to a tensor expression must be '
     #                         'abstract indices.'
     #                     )
-    new_indices = tuple([i.root if i is not Ellipsis else Ellipsis for i in
-                         as_tuple(indices or [])])
-    return P.index_notation(
-        node,
-        P.indices(new_indices)
-    )
-    # return P.index_notation(
-    #     node,
-    #     P.indices(tuple([i.root for i in as_tuple(indices or [])]))
-    # )
+    indices = tuple([i.root if i is not Ellipsis else
+                     P.ellipsis()
+                     for i in as_tuple(indices or [])])
+    return P.index_notation(node, P.indices(indices))
 
 
 @_dispatch

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -345,10 +345,16 @@ def _getitem(node: _ASNode, indices):  # noqa: F811
     #                         'Indices to a tensor expression must be '
     #                         'abstract indices.'
     #                     )
+    new_indices = tuple([i.root if i is not Ellipsis else Ellipsis for i in
+                         as_tuple(indices or [])])
     return P.index_notation(
         node,
-        P.indices(tuple([i.root for i in as_tuple(indices or [])]))
+        P.indices(new_indices)
     )
+    # return P.index_notation(
+    #     node,
+    #     P.indices(tuple([i.root for i in as_tuple(indices or [])]))
+    # )
 
 
 @_dispatch

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -19,6 +19,10 @@ class ASCIIRenderer(TranscribeInterpreter):
         return str(abstract.symbol)
 
     @as_payload
+    def ellipsis(self, ellipsis, **kwargs):
+        return repr(ellipsis)
+
+    @as_payload
     def index(self, item, bound, kron, **kwargs):
         if bound:
             return f'~{str(item.symbol)}'

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -5,7 +5,12 @@ import copy
 from enum import Enum
 from typing import Any, Callable, Iterable, Optional, Tuple
 from funfact.lang._ast import _ASNode, _AST, Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex,
+    AbstractEllipsis,
+    AbstractTensor,
+    LiteralValue
+)
 from funfact.util.iterable import flatten_if
 
 
@@ -49,6 +54,10 @@ class ROOFInterpreter(ABC):
 
     @abstractmethod
     def tensor(self, abstract: AbstractTensor, **payload):
+        pass
+
+    @abstractmethod
+    def ellipsis(self, ellipsis: AbstractEllipsis, **payload):
         pass
 
     @abstractmethod
@@ -155,6 +164,10 @@ class TranscribeInterpreter(ABC):
 
     @abstractmethod
     def tensor(self, abstract: AbstractTensor, **payload):
+        pass
+
+    @abstractmethod
+    def ellipsis(self, ellipsis: AbstractEllipsis, **payload):
         pass
 
     @abstractmethod

--- a/funfact/lang/interpreter/_einspec.py
+++ b/funfact/lang/interpreter/_einspec.py
@@ -3,7 +3,12 @@
 from typing import Optional, Tuple
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex,
+    AbstractEllipsis,
+    AbstractTensor,
+    LiteralValue
+)
 
 
 class IndexMap:
@@ -11,6 +16,8 @@ class IndexMap:
         self._index_map = {}
 
     def _map(self, idx):
+        if isinstance(idx, AbstractEllipsis):
+            return chr(46)
         try:
             return self._index_map[idx]
         except KeyError:
@@ -36,6 +43,9 @@ class EinsteinSpecGenerator(TranscribeInterpreter):
         return []
 
     def tensor(self, abstract: AbstractTensor, **kwargs):
+        return []
+
+    def ellipsis(self, ellipsis: AbstractEllipsis, **kwargs):
         return []
 
     def index(self, item: AbstractIndex, bound: bool, **kwargs):

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -4,7 +4,12 @@ import itertools as it
 from typing import Optional
 from ._base import dfs_filter, TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex,
+    AbstractEllipsis,
+    AbstractTensor,
+    LiteralValue
+)
 from funfact.util.set import ordered_intersect, ordered_union, ordered_setminus
 
 
@@ -79,6 +84,10 @@ class IndexAnalyzer(TranscribeInterpreter):
     @as_payload
     def tensor(self, abstract: AbstractTensor, **kwargs):
         return [], [], []
+
+    @as_payload
+    def ellipsis(self, ellipsis: AbstractEllipsis):
+        return [ellipsis], [ellipsis], []
 
     @as_payload
     def index(self, item: AbstractIndex, bound: bool, kron: bool, **kwargs):

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -38,6 +38,9 @@ class LeafInitializer(TranscribeInterpreter):
                 optimizable=optimizable
             )
 
+    def ellipsis(self, ellipsis, **kwargs):
+        return []
+
     def index(self, item, bound, kron, **kwargs):
         return []
 

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -34,6 +34,9 @@ class LatexRenderer(ROOFInterpreter):
     def tensor(self, abstract, **kwargs):
         return abstract._repr_tex_()
 
+    def ellipsis(self, ellipsis):
+        return ellipsis._repr_tex_()
+
     def index(self, item, bound, kron, **kwargs):
         if bound:
             accent = r'\widetilde'
@@ -44,7 +47,6 @@ class LatexRenderer(ROOFInterpreter):
         return fr'{{{item._repr_tex_(accent=accent)}}}'
 
     def indices(self, items, **kwargs):
-        items = [r'{\ldots}' if i is Ellipsis else i for i in items]
         return ''.join(items)
 
     def index_notation(self, indexless, indices, **kwargs):

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -44,6 +44,7 @@ class LatexRenderer(ROOFInterpreter):
         return fr'{{{item._repr_tex_(accent=accent)}}}'
 
     def indices(self, items, **kwargs):
+        items = [r'{\ldots}' if i is Ellipsis else i for i in items]
         return ''.join(items)
 
     def index_notation(self, indexless, indices, **kwargs):

--- a/funfact/lang/interpreter/_shape.py
+++ b/funfact/lang/interpreter/_shape.py
@@ -4,7 +4,12 @@ from typing import Optional, Tuple
 import numpy as np
 from ._base import TranscribeInterpreter
 from funfact.lang._ast import Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex,
+    AbstractEllipsis,
+    AbstractTensor,
+    LiteralValue
+)
 
 
 class ShapeAnalyzer(TranscribeInterpreter):
@@ -21,6 +26,10 @@ class ShapeAnalyzer(TranscribeInterpreter):
     @as_payload
     def tensor(self, abstract: AbstractTensor, **kwargs):
         return abstract.shape
+
+    @as_payload
+    def ellipsis(self, ellipsis: AbstractEllipsis, **kwargs):
+        return None
 
     @as_payload
     def index(self, item: AbstractIndex, bound: bool, **kwargs):
@@ -91,8 +100,21 @@ class ShapeAnalyzer(TranscribeInterpreter):
         pairwise: str, outidx: Optional[P.indices], live_indices, kron_indices,
         **kwargs
     ):
+        # TODO: for live_indices that are ellipsis multiple shapese have to be added
+        # See notebook.
+        '''
+        def map_shapes(live_indices, shape):
+            _dict = {}
+            for i in enumerate(live_indices):
+                if isinstance(i, AbstractEllipsis):
+                
+                else:
+                    _dict[i]
+        '''
         dict_lhs = dict(zip(lhs.live_indices, lhs.shape))
         dict_rhs = dict(zip(rhs.live_indices, rhs.shape))
+        print(dict_lhs)
+        print(dict_rhs)
 
         for i in lhs.live_indices:
             if i in rhs.live_indices and i not in kron_indices:


### PR DESCRIPTION
WIP towards #119 

This approach just leaves an Ellipsis as part of the index notations.
It renders a tsrex with an Ellipsis as follows:

```python
a = ff.tensor('a', 3, 2, 3, 4)
b = ff.tensor('b', 3, 2, 4, 6)
i, j, k = ff.indices('i, j, k')
tsrex = a[..., i, j] * b[..., j, k]
tsrex
```

$a_{{\ldots}{i}{j} \times b_{{\ldots}{j}{k}}$

I think a viable approach to evaluate this is to change the `EinsteinSpecGenerator` to create the following string for the above tensor expression: `'...ab,...bc->...ac|'` and add support for these types of spec strings to `einop`.

The shape and syntax analyzers would also need to be updated.

What do you think of this approach @yhtang ?