### PR TITLE
Change vectorizer rewriting rule. Fixes #135. Fixes #136.

### DIFF
--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -49,7 +49,7 @@ class Primitives:
         same index.'''
 
     @primitive(precedence=0)
-    def indices(items: Tuple[AbstractIndex]):
+    def indices(items: Tuple[index]):
         '''a tuple of indices'''
 
     @primitive(precedence=1)

--- a/funfact/lang/interpreter/_index_propagation.py
+++ b/funfact/lang/interpreter/_index_propagation.py
@@ -162,7 +162,7 @@ class IndexAnalyzer(TranscribeInterpreter):
             return implied_survival, lone_keep, kron
         else:
             explicit_survival = outidx.live_indices
-            explicit_kron = outidx.kron_indices
+            explicit_kron = ordered_union(kron, outidx.kron_indices)
             for i in keep:
                 if i not in explicit_survival:
                     raise SyntaxError(

--- a/funfact/lang/interpreter/_vectorize.py
+++ b/funfact/lang/interpreter/_vectorize.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import dataclasses
 from typing import Optional
 from funfact.lang._ast import Primitives as P
 from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
@@ -49,7 +50,7 @@ class LeafVectorizer(_VectorizerBase):
 
     def __init__(self, replicas: int, vec_index: P.index, append: bool = True):
         self.replicas = replicas
-        self.vec_index = vec_index
+        self.vec_index = dataclasses.replace(vec_index, bound=True)
         self.append = append
 
     def __call__(self, node, parent=None):
@@ -60,13 +61,11 @@ class LeafVectorizer(_VectorizerBase):
                 P.index(AbstractIndex(), bound=False, kron=False)
                 for _ in range(3)
             ]
-            node = P.ein(
+            node = P.binary(
                 P.index_notation(node.lhs, P.indices((i, j))),
                 P.index_notation(node.rhs, P.indices((j, k))),
                 precedence=node.precedence,
-                reduction='sum',
-                pairwise='multiply',
-                outidx=None
+                oper='multiply'
             )
 
         elif isinstance(node, P.kron):
@@ -75,13 +74,11 @@ class LeafVectorizer(_VectorizerBase):
                 P.index(AbstractIndex(), bound=False, kron=True)
                 for _ in range(2)
             ]
-            node = P.ein(
+            node = P.binary(
                 P.index_notation(node.lhs, P.indices((i, j))),
                 P.index_notation(node.rhs, P.indices((i, j))),
                 precedence=node.precedence,
-                reduction='sum',
-                pairwise='multiply',
-                outidx=None
+                oper='multiply'
             )
 
         node = super().__call__(node, parent)
@@ -110,7 +107,7 @@ class EinopVectorizer(_VectorizerBase):
     as_payload = TranscribeInterpreter.as_payload
 
     def __init__(self, vec_index: P.index, append: bool = True):
-        self.vec_index = vec_index
+        self.vec_index = dataclasses.replace(vec_index, bound=True)
         self.append = append
 
     def tensor(self, abstract: AbstractTensor, **kwargs):

--- a/funfact/lang/interpreter/_vectorize.py
+++ b/funfact/lang/interpreter/_vectorize.py
@@ -107,7 +107,7 @@ class EinopVectorizer(_VectorizerBase):
     as_payload = TranscribeInterpreter.as_payload
 
     def __init__(self, vec_index: P.index, append: bool = True):
-        self.vec_index = dataclasses.replace(vec_index, bound=True)
+        self.vec_index = dataclasses.replace(vec_index, bound=False)
         self.append = append
 
     def tensor(self, abstract: AbstractTensor, **kwargs):
@@ -121,9 +121,12 @@ class EinopVectorizer(_VectorizerBase):
         self, lhs: P.Numeric, rhs: P.Numeric, precedence: int, reduction: str,
         pairwise: str, outidx: Optional[P.indices], live_indices, **kwargs
     ):
-
-        indices = [P.index(i, bound=False, kron=False) for i in live_indices
-                   if i != self.vec_index.item]
+        if outidx is not None:
+            live_indices = [i.item for i in outidx.items]
+        indices = [
+            P.index(i, bound=False, kron=False) for i in live_indices
+            if i != self.vec_index.item
+        ]
         if self.append:
             return P.indices([*indices, self.vec_index])
         else:

--- a/funfact/vectorization.py
+++ b/funfact/vectorization.py
@@ -36,9 +36,9 @@ def vectorize(tsrex, n, append: bool = True):
         TsrEx:
             A vectorized tensor expression.
     '''
-    i = index().root
-    return tsrex | LeafVectorizer(n, i, append) | IndexAnalyzer() \
-                 | EinopVectorizer(i, append)
+    i = index()
+    return tsrex | LeafVectorizer(n, i.root, append) | IndexAnalyzer() \
+                 | EinopVectorizer(i.root, append)
 
 
 def view(fac, tsrex_scalar, instance: int):


### PR DESCRIPTION
AChained indexless operations can be correctly vectorized now.
``` py
A = ff.eye(2)
B = ff.tensor(2, 2)
C = ff.eye(2)
tsrex = A & B & C
tsrex_vec = vectorize(tsrex, 4, append=True)
```
~~However, a backend bug popped up after the frontend is fixed. See #136 for details.~~
Also fixes #136, which is due to a bug in the index analyzer.