### PR TITLE
Use matrix strategy to test both PyTorch and JAX backends during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        backend: ['JAX', 'PyTorch']
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -37,6 +38,8 @@ jobs:
           pip install tox tox-gh-actions
       - name: Test with tox
         run: tox
+        env:
+          BACKEND: ${{ matrix.backend }}
   coverage:
     runs-on: ubuntu-latest
     name: Coverage Test

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -42,7 +42,7 @@ class PyTorchBackend(metaclass=BackendMeta):
     def uniform(cls, low, high, shape, dtype=torch.float32):
         with torch.no_grad():
             return torch.rand(
-                *shape, dtype=dtype, generator=cls._gen
+                shape, dtype=dtype, generator=cls._gen
             ) * (high - low) + low
 
     @classmethod

--- a/funfact/initializers.py
+++ b/funfact/initializers.py
@@ -14,7 +14,7 @@ class Zeros:
         self.dtype = dtype or ab.float32
 
     def __call__(self, shape):
-        return ab.zeros(shape, self.dtype)
+        return ab.zeros(shape, dtype=self.dtype)
 
 
 class Ones:
@@ -27,7 +27,7 @@ class Ones:
         self.dtype = dtype or ab.float32
 
     def __call__(self, shape):
-        return ab.ones(shape, self.dtype)
+        return ab.ones(shape, dtype=self.dtype)
 
 
 class Eye:
@@ -65,11 +65,11 @@ class Normal:
         self.std = std
         self.dtype = dtype or ab.float32
         if truncation is True:
-            self.truncation = 2.0 * std
+            self.truncation = ab.tensor(2.0 * std, dtype=self.dtype)
         elif truncation is False:
-            self.truncation = 0
+            self.truncation = ab.tensor(0.0, dtype=self.dtype)
         else:
-            self.truncation = float(truncation) * std
+            self.truncation = ab.tensor(truncation * std, dtype=self.dtype)
 
     def __call__(self, shape):
         n = ab.normal(0.0, self.std, as_tuple(shape), dtype=self.dtype)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,19 @@
 [tox]
-envlist = py37,py38,py39,coverage,benchmark,docs
+envlist =
+    py{37,38,39}-{jax,torch},
+    coverage,benchmark,docs
 
 [testenv]
+basepython =
+    py37: python3.7
+    py38: python3.8
+    py39: python3.9
 changedir = funfact
 whitelist_externals = bash
 extras =
     devel
+    jax: jax
+    torch: torch
 commands =
     pytest
 
@@ -20,15 +28,6 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-
-[testenv:py37]
-basepython = python3.7
-
-[testenv:py38]
-basepython = python3.8
-
-[testenv:py39]
-basepython = python3.9
 
 [testenv:coverage]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,11 @@ python =
     3.8: py38
     3.9: py39
 
+[gh-actions:env]
+BACKEND =
+    JAX: jax
+    PyTorch: torch
+
 [testenv:coverage]
 basepython = python3.8
 commands =


### PR DESCRIPTION
Replaces #138, which ended up merging into the wrong branch...

Original PR message:

With the new Tox/CI config, we can specify the backend used in unit testing and CI runs.

Example usage:
``` bash
tox -e py38-jax
tox -e py39-torch
...
```