### PR TITLE
full support for prepend vectorization

### DIFF
--- a/funfact/algorithm.py
+++ b/funfact/algorithm.py
@@ -92,10 +92,10 @@ def factorize(
                 'funfact.loss.'
             )
     try:
-        loss(target, target, append=append, **kwargs)
+        loss(target, target, **kwargs)
     except Exception as e:
         raise AssertionError(
-            f'The given loss function does not accept three arguments:\n{e}'
+            f'The given loss function does not accept two arguments:\n{e}'
         )
 
     if isinstance(optimizer, str):
@@ -117,7 +117,8 @@ def factorize(
             'Invalid optimization algorithm:\n{e}'
         )
 
-    loss_and_grad = ab.loss_and_grad(loss, opt_fac, target, append=append)
+    loss_and_grad = ab.loss_and_grad(loss, opt_fac, target,
+                                     vectorized_along_last=append)
 
     # bookkeeping
     best_factors = [np.zeros_like(ab.to_numpy(x)) for x in opt_fac.factors]
@@ -132,7 +133,7 @@ def factorize(
             if step % checkpoint_freq == 0:
                 # update best factorization
                 curr_loss = ab.to_numpy(loss(opt_fac(), target, sum_vec=False,
-                                             append=append))
+                                             vectorized_along_last=append))
                 better = np.flatnonzero(curr_loss < best_loss)
                 best_loss = np.minimum(best_loss, curr_loss)
                 for b, o in zip(best_factors, opt_fac.factors):

--- a/funfact/backend/_jax.py
+++ b/funfact/backend/_jax.py
@@ -41,10 +41,10 @@ class JAXBackend(metaclass=BackendMeta):
         return jrn.uniform(subkey, shape, dtype, minval=low, maxval=high)
 
     @staticmethod
-    def loss_and_grad(loss_fn, example_model, example_target):
+    def loss_and_grad(loss_fn, example_model, example_target, **kwargs):
         loss_and_grad_fn = jax.jit(
             jax.value_and_grad(
-                lambda model, target: loss_fn(model(), target)
+                lambda model, target: loss_fn(model(), target, **kwargs)
             )
         )
 

--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -65,9 +65,9 @@ class PyTorchBackend(metaclass=BackendMeta):
             )
 
     @staticmethod
-    def loss_and_grad(loss_fn, example_model, example_target):
+    def loss_and_grad(loss_fn, example_model, example_target, **kwargs):
         def wrapper(model, target):
-            loss = loss_fn(model(), target)
+            loss = loss_fn(model(), target, **kwargs)
             gradients = torch.autograd.grad(loss, model)
             # gradients = [data.grad for data in model.factors]
             return loss, gradients

--- a/funfact/lang/interpreter/_vectorize.py
+++ b/funfact/lang/interpreter/_vectorize.py
@@ -47,7 +47,8 @@ class LeafVectorizer(_VectorizerBase):
 
     as_payload = TranscribeInterpreter.as_payload
 
-    def __init__(self, replicas: int, vec_index: P.index, append: bool = True):
+    def __init__(self, replicas: int, vec_index: P.index,
+                 append: bool = False):
         self.replicas = replicas
         self.vec_index = vec_index
         self.append = append
@@ -109,7 +110,7 @@ class EinopVectorizer(_VectorizerBase):
 
     as_payload = TranscribeInterpreter.as_payload
 
-    def __init__(self, vec_index: P.index, append: bool = True):
+    def __init__(self, vec_index: P.index, append: bool = False):
         self.vec_index = vec_index
         self.append = append
 

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -12,7 +12,7 @@ class Loss(ABC):
         pass
 
     def __call__(self, model, target, reduction='mean', sum_vec=True,
-                 vectorized_along_last=True, **kwargs):
+                 vectorized_along_last=False, **kwargs):
         '''Evaluate the loss function.
 
         Args:

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -12,14 +12,15 @@ class Loss(ABC):
         pass
 
     def __call__(self, model, target, reduction='mean', sum_vec=True,
-                 **kwargs):
-        if target.ndim == model.ndim - 1:
-            if model.shape[:-1] != target.shape:
-                raise ValueError(f'Target shape {target.shape} and '
-                                 f'model shape {model.shape[:-1]} mismatch.')
-            data_axis = tuple(i for i in range(target.ndim))
-            target = target[..., None]
-        elif target.ndim == model.ndim:
+                 append=True, **kwargs):
+        if target.ndim == model.ndim - 1:  # vectorized model
+            model_shape = model.shape[:-1] if append else model.shape[1:]
+            if model_shape != target.shape:
+                raise ValueError(f'Target shape {target.shape} and model '
+                                 f'shape {model_shape} mismatch.')
+            data_axis = tuple(i if append else i+1 for i in range(target.ndim))
+            target = target[..., None] if append else target[None, ...]
+        elif target.ndim == model.ndim:  # non-vectorized model
             data_axis = tuple(i for i in range(target.ndim))
             if model.shape != target.shape:
                 raise ValueError(f'Target shape {target.shape} and '

--- a/funfact/vectorization.py
+++ b/funfact/vectorization.py
@@ -9,7 +9,7 @@ from funfact.lang.interpreter import (
 from funfact.model import Factorization
 
 
-def vectorize(tsrex, n, append: bool = True):
+def vectorize(tsrex, n, append: bool = False):
     ''''Vectorize' a tensor expression by extending its dimensionality by one.
     Each slice along the vectorization dimension of a factorization model
     represents an independent realization of the original tensor expression.
@@ -41,7 +41,7 @@ def vectorize(tsrex, n, append: bool = True):
                  | EinopVectorizer(i, append)
 
 
-def view(fac, tsrex_scalar, instance: int, append: bool = True):
+def view(fac, tsrex_scalar, instance: int, append: bool = False):
     '''Obtain a zero-copy instance from a vectorized factorization model.
 
     Args:

--- a/funfact/vectorization.py
+++ b/funfact/vectorization.py
@@ -52,7 +52,8 @@ def view(fac, tsrex_scalar, instance: int, append: bool = True):
         instance (int):
             Index along the vectorization dimension.
         append (bool):
-            Appended or prepended vectorization dimension.
+            Indicates whether the vectorization dimension was appended
+            or prepended.
 
     Returns:
         Factorization:

--- a/funfact/vectorization.py
+++ b/funfact/vectorization.py
@@ -41,7 +41,7 @@ def vectorize(tsrex, n, append: bool = True):
                  | EinopVectorizer(i, append)
 
 
-def view(fac, tsrex_scalar, instance: int):
+def view(fac, tsrex_scalar, instance: int, append: bool = True):
     '''Obtain a zero-copy instance from a vectorized factorization model.
 
     Args:
@@ -51,17 +51,21 @@ def view(fac, tsrex_scalar, instance: int):
             The original, un-vectorized tensor expression.
         instance (int):
             Index along the vectorization dimension.
+        append (bool):
+            Appended or prepended vectorization dimension.
 
     Returns:
         Factorization:
             A factorization model.
     '''
-    if instance >= fac.shape[-1]:
+    nvec = fac.shape[-1] if append else fac.shape[0]
+    if instance >= nvec:
         raise IndexError(
-            f'Only {fac.shape[-1]} vector instances exist, '
+            f'Only {nvec} vector instances exist, '
             f'index {instance} out of range.'
         )
     fac_scalar = Factorization(tsrex_scalar)
+    instance = [..., instance] if append else [instance, ...]
     for i, f in enumerate(fac.all_factors):
-        fac_scalar.all_factors[i] = f[..., instance]
+        fac_scalar.all_factors[i] = f[tuple(instance)]
     return fac_scalar


### PR DESCRIPTION
This adds complete support for prepending vectorization to:

- FF loss functions
- vectorization.view 
- factorize
- backends

The following code now works correctly:

```python
A = ff.tensor('A', 3, 2)
B = ff.tensor('B', 2, 3)
i, j, k = ff.indices('i, j, k')
#tsrex = A[[*i, *j]] * B[[i, j]]
tsrex = A[[i, j]] * B[[j, k]]
target = ff.Factorization.from_tsrex(tsrex)
target = target()
fac = ff.factorize(tsrex, target, nvec=4, append=False)
fac()
```