### PR TITLE
Refactored einop. Closes #109

### DIFF
--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -95,11 +95,6 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
                     p_rhs += 1
                     p_out += 1
 
-    print('ax_contraction', ax_contraction)
-    print('ax_expand_lhs', ax_expand_lhs)
-    print('ax_expand_rhs', ax_expand_rhs)
-    print('target_shape', target_shape)
-
     # compute the contraction in alphabetical order
     op_redu = getattr(ab, reduction)
     op_pair = getattr(ab, pairwise)
@@ -109,10 +104,6 @@ def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
             return op_redu(tensor, tuple(ax_contraction))
         else:
             return tensor
-
-    print(lhs.shape)
-    print(ab.expand_dims(lhs, ax_expand_lhs).shape)
-    print(ab.expand_dims(rhs, ax_expand_rhs).shape)
 
     return ab.reshape(
         op_reduce_if(


### PR DESCRIPTION
Despite what the branch name suggests, I ended up still using the `None/Slice(None)` trick to expand the dimensionality of operand tensors. However, this PR achieves two things:

1. Via a different ordering of the indices, we only need to transpose the lhs/rhs tensors. There is no need to transpose the result tensors anymore.
2. This streamlines the transpose-pairwise-reduce-reshape call and paves the way to solve #179.