### PR TITLE
Precompile einop specifications using live indices. Fixes #182.

### DIFF
--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -13,7 +13,7 @@ from ._ast import _AST, _ASNode, Primitives as P
 from .interpreter import (
     ASCIIRenderer,
     TypeDeducer,
-    EinsteinSpecGenerator,
+    EinopCompiler,
     IndexnessAnalyzer,
     LatexRenderer,
 )
@@ -96,7 +96,7 @@ class _BaseEx(_AST):
     _latex_intr = LatexRenderer()
     _asciitree_factory = ASCIITreeFactory()
     _type_deducer = TypeDeducer()
-    _einspec_generator = EinsteinSpecGenerator()
+    _einop_compiler = EinopCompiler()
     _indexness_analyzer = IndexnessAnalyzer()
 
     @functools.lru_cache()
@@ -154,7 +154,7 @@ class _BaseEx(_AST):
         return (self |
                 self._indexness_analyzer |
                 self._type_deducer |
-                self._einspec_generator).root
+                self._einop_compiler).root
 
     @property
     def shape(self):

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -12,7 +12,7 @@ from funfact.util.iterable import as_namedtuple, as_tuple, flatten_if
 from ._ast import _AST, _ASNode, Primitives as P
 from .interpreter import (
     ASCIIRenderer,
-    Compiler,
+    TypeDeducer,
     EinsteinSpecGenerator,
     IndexnessAnalyzer,
     LatexRenderer,
@@ -95,7 +95,7 @@ class _BaseEx(_AST):
 
     _latex_intr = LatexRenderer()
     _asciitree_factory = ASCIITreeFactory()
-    _compiler = Compiler()
+    _type_deducer = TypeDeducer()
     _einspec_generator = EinsteinSpecGenerator()
     _indexness_analyzer = IndexnessAnalyzer()
 
@@ -153,7 +153,7 @@ class _BaseEx(_AST):
     def _static_analyzed(self):
         return (self |
                 self._indexness_analyzer |
-                self._compiler |
+                self._type_deducer |
                 self._einspec_generator).root
 
     @property

--- a/funfact/lang/interpreter/__init__.py
+++ b/funfact/lang/interpreter/__init__.py
@@ -3,7 +3,7 @@
 from ._ascii import ASCIIRenderer
 from ._base import dfs, dfs_filter, PayloadMerger
 from ._evaluation import Evaluator
-from ._einspec import EinsteinSpecGenerator
+from ._einop_compiler import EinopCompiler
 from ._type_deduction import TypeDeducer
 from ._indexness import IndexnessAnalyzer
 from ._initialization import LeafInitializer
@@ -19,7 +19,7 @@ __all__ = [
     'ASCIIRenderer',
     'TypeDeducer',
     'Evaluator',
-    'EinsteinSpecGenerator',
+    'EinopCompiler',
     'IndexnessAnalyzer',
     'LeafInitializer',
     'LatexRenderer',

--- a/funfact/lang/interpreter/__init__.py
+++ b/funfact/lang/interpreter/__init__.py
@@ -4,7 +4,7 @@ from ._ascii import ASCIIRenderer
 from ._base import dfs, dfs_filter, PayloadMerger
 from ._evaluation import Evaluator
 from ._einspec import EinsteinSpecGenerator
-from ._compile import Compiler
+from ._type_deduction import TypeDeducer
 from ._indexness import IndexnessAnalyzer
 from ._initialization import LeafInitializer
 from ._latex import LatexRenderer
@@ -17,7 +17,7 @@ __all__ = [
     'dfs',
     'dfs_filter',
     'ASCIIRenderer',
-    'Compiler',
+    'TypeDeducer',
     'Evaluator',
     'EinsteinSpecGenerator',
     'IndexnessAnalyzer',

--- a/funfact/lang/interpreter/_einop.py
+++ b/funfact/lang/interpreter/_einop.py
@@ -1,121 +1,25 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# import jax.numpy as np
-# import numpy
-import re
-import numpy as np
 from funfact.backend import active_backend as ab
-from funfact.util.set import ordered_symmdiff
 
 
-def _einop(spec: str, lhs, rhs, reduction: str, pairwise: str):
-    '''Einstein operation between two nd arrays.
-    TODO: update documentation.
-    Parameters
-    ----------
-    spec: str
-        Specification string for index contraction. The following
-        options are supported:
-            'abc,ad->bcd', 'abc,ad->cbd', ....
-            'abc,ad->abcd', 'abc,ad->bacd', ...
-            'abc,ad->cd', 'abc,ad->bd', ...
-            'abc,ad->b', 'abc,ad->c', ...
-            'abc,ad->'
-    lhs: array
-        Left hand side array
-    rhs: array
-        Right hand side array
-    reduction: str
-        Name of the reduction operator
-    pairwise: str
-        Name of the pairwise operator
-    '''
-    # parse input spec string
-    out = re.fullmatch(r'(\w*),(\w*)(->(\w*))?(\|(\w*))?', spec)
-    lhs_spec = list(out.group(1))
-    rhs_spec = list(out.group(2))
-    out_spec = list(out.group(4) or ordered_symmdiff(lhs_spec, rhs_spec))
-    kron_spec = list(out.group(6) or [])
+def _einop(lhs, rhs, spec, output_shape):
+    '''Einstein operation between two nd arrays.'''
 
-    # move all surviving indices to the front and sort the rest
-    indices_all = out_spec + sorted(
-        set(lhs_spec).union(rhs_spec).difference(out_spec)
+    if spec.tran_lhs:
+        lhs = ab.transpose(lhs, spec.tran_lhs)
+    if spec.tran_rhs:
+        rhs = ab.transpose(rhs, spec.tran_rhs)
+
+    elementwise = getattr(ab, spec.op_elementwise)(
+        lhs[spec.index_lhs], rhs[spec.index_rhs]
     )
 
-    # reorder lhs and rhs following the order in all indices
-    if lhs_spec:
-        lhs = ab.transpose(lhs, np.argsort([
-            indices_all.index(i) for i in lhs_spec
-        ]))
-    if rhs_spec:
-        rhs = ab.transpose(rhs, np.argsort([
-            indices_all.index(i) for i in rhs_spec
-        ]))
+    if spec.ax_contraction:
+        contracted = getattr(ab, spec.op_reduce)(
+            elementwise, spec.ax_contraction
+        )
+    else:
+        contracted = elementwise
 
-    # Determine expansion positions to align the contraction, Kronecker,
-    # elementwise, and outer product indices
-    p_out, p_lhs, p_rhs = 0, 0, 0
-    newaxis, colon = None, slice(None)
-    index_lhs = []
-    index_rhs = []
-    ax_contraction = []
-    target_shape = []
-
-    for c in indices_all:
-        if c not in out_spec:  # contracting index
-            ax_contraction.append(p_out)
-            index_lhs.append(colon)
-            index_rhs.append(colon)
-            p_lhs += 1
-            p_rhs += 1
-            p_out += 1
-        else:  # non-contracting index
-            if c in kron_spec:
-                index_lhs += [colon, newaxis]
-                index_rhs += [newaxis, colon]
-                target_shape.append(lhs.shape[p_lhs] * rhs.shape[p_rhs])
-                p_lhs += 1
-                p_rhs += 1
-                p_out += 2
-            else:
-                if c in lhs_spec and c in rhs_spec:
-                    target_shape.append(
-                        *ab.broadcast_shapes(
-                            lhs.shape[p_lhs], rhs.shape[p_rhs]
-                        )
-                    )
-                    index_lhs.append(colon)
-                    index_rhs.append(colon)
-                    p_lhs += 1
-                    p_rhs += 1
-                    p_out += 1
-                elif c in lhs_spec:
-                    index_lhs.append(colon)
-                    index_rhs.append(newaxis)
-                    target_shape.append(lhs.shape[p_lhs])
-                    p_lhs += 1
-                    p_out += 1
-                elif c in rhs_spec:
-                    index_lhs.append(newaxis)
-                    index_rhs.append(colon)
-                    target_shape.append(rhs.shape[p_rhs])
-                    p_rhs += 1
-                    p_out += 1
-
-    # compute the contraction in alphabetical order
-    op_redu = getattr(ab, reduction)
-    op_pair = getattr(ab, pairwise)
-
-    def op_reduce_if(tensor, ax_contraction):
-        if ax_contraction:
-            return op_redu(tensor, tuple(ax_contraction))
-        else:
-            return tensor
-
-    return ab.reshape(
-        op_reduce_if(
-            op_pair(lhs[tuple(index_lhs)], rhs[tuple(index_rhs)]),
-            ax_contraction
-        ),
-        tuple(target_shape),
-    )
+    return ab.reshape(contracted, output_shape)

--- a/funfact/lang/interpreter/_einop_compiler.py
+++ b/funfact/lang/interpreter/_einop_compiler.py
@@ -24,7 +24,7 @@ class IndexMap:
             return self._map(ids)
 
 
-class EinsteinSpecGenerator(TranscribeInterpreter):
+class EinopCompiler(TranscribeInterpreter):
     '''The Einstein summation specification generator creates NumPy-style spec
     strings for tensor contraction operations.'''
 

--- a/funfact/lang/interpreter/_einop_compiler.py
+++ b/funfact/lang/interpreter/_einop_compiler.py
@@ -65,12 +65,14 @@ class EinopCompiler(TranscribeInterpreter):
     ):
         lhs_live = lhs.live_indices or []
         rhs_live = rhs.live_indices or []
+        lhs_kron = lhs.kron_indices or []
+        rhs_kron = rhs.kron_indices or []
 
         # move all surviving indices to the front and sort the rest
         all_indices = live_indices + sorted(
             (set(lhs_live) | set(rhs_live)) - set(live_indices or [])
         )
-        kron_indices = set(lhs.kron_indices or []) | set(rhs.kron_indices or [])
+        kron_set = set(lhs_kron) | set(rhs_kron)
 
         # reorder lhs and rhs following the order in all indices
         tran_lhs = np.argsort([all_indices.index(i) for i in lhs_live])
@@ -93,7 +95,7 @@ class EinopCompiler(TranscribeInterpreter):
                 p_rhs += 1
                 p_out += 1
             else:  # non-contracting index
-                if i in kron_indices:
+                if i in kron_set:
                     index_lhs += [colon, newaxis]
                     index_rhs += [newaxis, colon]
                     p_lhs += 1

--- a/funfact/lang/interpreter/_elementwise.py
+++ b/funfact/lang/interpreter/_elementwise.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from funfact.lang.interpreter._evaluation import Evaluator
+from ._einop import _einop
+
+
+def _sliced_size(sli, sz):
+    if isinstance(sli, slice):
+        return len(range(*sli.indices(sz)))
+    elif isinstance(sli, tuple):
+        return len(sli)
+    else:
+        raise RuntimeError(f'Invalid slice {sli}.')
 
 
 class ElementwiseEvaluator(Evaluator):
     def tensor(self, decl, data, slices, **kwargs):
-        return data[tuple(slices)]
+        return data[slices]
+
+    def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, einspec,
+            shape, slices, **kwargs):
+        return _einop(lhs, rhs, einspec, [
+            _sliced_size(slice, size) for slice, size in zip(slices, shape)
+        ])

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -9,10 +9,6 @@ class Evaluator(ROOFInterpreter):
     '''The evaluation interpreter evaluates an initialized tensor expression.
     '''
 
-    @staticmethod
-    def _binary_operator(reduction, pairwise, lhs, rhs, spec):
-        return _einop(spec, lhs, rhs, reduction, pairwise)
-
     def abstract_index_notation(self, tensor, indices, **kwargs):
         raise NotImplementedError()
 
@@ -44,8 +40,8 @@ class Evaluator(ROOFInterpreter):
         return getattr(ab, operator)(lhs, rhs)
 
     def ein(self, lhs, rhs, precedence, reduction, pairwise, outidx, einspec,
-            **kwargs):
-        return self._binary_operator(reduction, pairwise, lhs, rhs, einspec)
+            shape, **kwargs):
+        return _einop(lhs, rhs, einspec, shape)
 
     def tran(self, src, indices, einspec, **kwargs):
         in_spec, out_spec = einspec.split('->')

--- a/funfact/lang/interpreter/_type_deduction.py
+++ b/funfact/lang/interpreter/_type_deduction.py
@@ -20,7 +20,7 @@ def _add_attr(node, **kwargs):
     return node
 
 
-class Compiler(RewritingTranscriber):
+class TypeDeducer(RewritingTranscriber):
     '''Analyzes which of the indices survive in a tensor operations and does
     AST rewrite to replace certain operations with specialized Einstein
     operations and index renaming operations.'''

--- a/funfact/lang/interpreter/test_einop.py
+++ b/funfact/lang/interpreter/test_einop.py
@@ -1,113 +1,621 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest  # noqa: F401
+from collections import namedtuple
 from funfact.backend import active_backend as ab
 from ._einop import _einop
 
 
+_einspec = namedtuple(
+    'einspec', [
+        'op_reduce', 'op_elementwise', 'tran_lhs', 'tran_rhs', 'index_lhs',
+        'index_rhs', 'ax_contraction'
+    ]
+)
+
+
 @pytest.mark.parametrize('case', [
     # scalar multiplication
-    ((), (), ',->'),
+    (
+        (), (), (),
+        ',->',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(),
+            tran_rhs=(),
+            index_lhs=(),
+            index_rhs=(),
+            ax_contraction=()),
+    ),
     # right elementwise multiplication
-    ((3,), (), 'a,->a'),
-    ((3,), (), 'a,->a'),
-    ((3,), (), 'a,'),
-    ((3, 2), (), 'ab,->ab'),
-    ((3, 2), (), 'ab,'),
+    (
+        (3,), (), (3,),
+        'a,->a',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(),
+            index_lhs=(slice(None),),
+            index_rhs=(None,),
+            ax_contraction=()),
+    ),
+    (
+        (3,), (), (3,),
+        'a,->a',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(),
+            index_lhs=(slice(None),),
+            index_rhs=(None,),
+            ax_contraction=()),
+    ),
+    (
+        (3,), (), (3,),
+        'a,',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(),
+            index_lhs=(slice(None),),
+            index_rhs=(None,),
+            ax_contraction=()),
+    ),
+    (
+        (3, 2), (), (3, 2),
+        'ab,->ab',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(),
+            index_lhs=(slice(None), slice(None)),
+            index_rhs=(None, None),
+            ax_contraction=()),
+    ),
+    (
+        (3, 2), (), (3, 2),
+        'ab,',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(),
+            index_lhs=(slice(None), slice(None)),
+            index_rhs=(None, None),
+            ax_contraction=()),
+    ),
     # left elementwise multiplication
-    ((), (3,), ',a->a'),
-    ((), (3,), ',a->a'),
-    ((), (3,), ',a'),
-    ((), (3, 2), ',ab->ab'),
+    (
+        (), (3,), (3,),
+        ',a->a',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(),
+            tran_rhs=(0,),
+            index_lhs=(None,),
+            index_rhs=(slice(None),),
+            ax_contraction=()),
+    ),
+    (
+        (), (3,), (3,),
+        ',a->a',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(),
+            tran_rhs=(0,),
+            index_lhs=(None,),
+            index_rhs=(slice(None),),
+            ax_contraction=()),
+    ),
+    (
+        (), (3,), (3,),
+        ',a',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(),
+            tran_rhs=(0,),
+            index_lhs=(None,),
+            index_rhs=(slice(None),),
+            ax_contraction=()),
+    ),
+    (
+        (), (3, 2), (3, 2),
+        ',ab->ab',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(),
+            tran_rhs=(0, 1),
+            index_lhs=(None, None),
+            index_rhs=(slice(None), slice(None)),
+            ax_contraction=()),
+    ),
     # vector dot product
-    ((10,), (10,), 'i,i'),
-    ((10,), (10,), 'i,i->i'),
+    (
+        (10,), (10,), (),
+        'i,i',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (10,),
+        'i,i->i',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=()),
+    ),
     # matrix elementwise multiplication
-    ((3, 2), (3, 2), 'ab,ab->ab'),
+    (
+        (3, 2), (3, 2), (3, 2),
+        'ab,ab->ab',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), slice(None)),
+            index_rhs=(slice(None), slice(None)),
+            ax_contraction=()),
+    ),
     # inner product and contractions
-    ((10, 3), (3, 10), 'ij,jk'),
-    ((10, 3), (3, 10), 'ij,jk->ijk'),
-    ((2, 3, 4), (3, 4, 5), 'ijk,jkl'),
-    ((2, 3, 4), (3, 4), 'ijk,jk'),
-    ((2, 3, 4), (5, 4, 3), 'ijk,lkj'),
-    ((4, 3, 2), (5, 4, 3), 'ijk,lij'),
+    (
+        (10, 3), (3, 10), (10, 10),
+        'ij,jk',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(1, 0),
+            index_lhs=(slice(None), None, slice(None)),
+            index_rhs=(None, slice(None), slice(None)),
+            ax_contraction=(2,)),
+    ),
+    (
+        (10, 3), (3, 10), (10, 3, 10),
+        'ij,jk->ijk',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), slice(None), None),
+            index_rhs=(None, slice(None), slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 3, 4), (3, 4, 5), (2, 5),
+        'ijk,jkl',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1, 2),
+            tran_rhs=(2, 0, 1),
+            index_lhs=(slice(None), None, slice(None), slice(None)),
+            index_rhs=(None, slice(None), slice(None), slice(None)),
+            ax_contraction=(2, 3)),
+    ),
+    (
+        (2, 3, 4), (3, 4), (2,),
+        'ijk,jk',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1, 2),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), slice(None), slice(None)),
+            index_rhs=(None, slice(None), slice(None)),
+            ax_contraction=(1, 2)),
+    ),
+    (
+        (2, 3, 4), (5, 4, 3), (2, 5),
+        'ijk,lkj',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1, 2),
+            tran_rhs=(0, 2, 1),
+            index_lhs=(slice(None), None, slice(None), slice(None)),
+            index_rhs=(None, slice(None), slice(None), slice(None)),
+            ax_contraction=(2, 3)),
+    ),
+    (
+        (4, 3, 2), (5, 4, 3), (2, 5),
+        'ijk,lij',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(2, 0, 1),
+            tran_rhs=(0, 1, 2),
+            index_lhs=(slice(None), None, slice(None), slice(None)),
+            index_rhs=(None, slice(None), slice(None), slice(None)),
+            ax_contraction=(2, 3)),
+    ),
 ])
 def test_einsum(case):
     tol = 100 * ab.finfo(ab.float32).eps
 
-    lhs_shape, rhs_shape, spec = case
+    lhs_shape, rhs_shape, result_shape, npspec, ffspec = case
     lhs = ab.normal(0.0, 1.0, lhs_shape)
     rhs = ab.normal(0.0, 1.0, rhs_shape)
-    truth = ab.einsum(spec, lhs, rhs)
-    res = _einop(spec, lhs, rhs, 'sum', 'multiply')
+    truth = ab.einsum(npspec, lhs, rhs)
+    res = _einop(lhs, rhs, ffspec, result_shape)
     assert truth.shape == res.shape
     assert ab.allclose(truth, res, tol)
 
 
 @pytest.mark.parametrize('case', [
-    ((10,), (10,), 'i,j', 'sum', 'add'),
-    ((10,), (10,), 'i,j', 'sum', 'subtract'),
-    ((10,), (10,), 'i,j', 'sum', 'multiply'),
-    ((10,), (10,), 'i,j', 'sum', 'divide'),
+    (
+        (10,), (10,), (10, 10),
+        'add',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='add',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None), None),
+            index_rhs=(None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (10,), (10,), (10, 10),
+        'subtract',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='subtract',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None), None),
+            index_rhs=(None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (10,), (10,), (10, 10),
+        'multiply',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None), None),
+            index_rhs=(None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (10,), (10,), (10, 10),
+        'divide',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='divide',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None), None),
+            index_rhs=(None, slice(None)),
+            ax_contraction=()),
+    ),
 ])
 def test_generic_outer(case):
     tol = 20 * ab.finfo(ab.float32).eps
 
-    lhs_shape, rhs_shape, spec, reduction, pairwise = case
+    lhs_shape, rhs_shape, result_shape, pairwise, ffspec = case
     lhs = ab.normal(0.0, 1.0, lhs_shape)
     rhs = ab.normal(0.0, 1.0, rhs_shape)
     truth = getattr(ab, pairwise)(lhs[:, None], rhs[None, :])
-    res = _einop(spec, lhs, rhs, reduction, pairwise)
+    res = _einop(lhs, rhs, ffspec, result_shape)
     assert truth.shape == res.shape
     assert ab.allclose(truth, res, tol)
 
 
 @pytest.mark.parametrize('case', [
-    ((10,), (10,), 'i,i', 'sum', 'add'),
-    ((10,), (10,), 'i,i', 'sum', 'subtract'),
-    ((10,), (10,), 'i,i', 'sum', 'multiply'),
-    ((10,), (10,), 'i,i', 'sum', 'divide'),
-    ((10,), (10,), 'i,i', 'min', 'add'),
-    ((10,), (10,), 'i,i', 'min', 'subtract'),
-    ((10,), (10,), 'i,i', 'min', 'multiply'),
-    ((10,), (10,), 'i,i', 'min', 'divide'),
-    ((10,), (10,), 'i,i', 'max', 'add'),
-    ((10,), (10,), 'i,i', 'max', 'subtract'),
-    ((10,), (10,), 'i,i', 'max', 'multiply'),
-    ((10,), (10,), 'i,i', 'max', 'divide'),
+    (
+        (10,), (10,), (),
+        'sum', 'add',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='add',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'sum', 'subtract',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='subtract',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'sum', 'multiply',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'sum', 'divide',
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='divide',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'min', 'add',
+        _einspec(
+            op_reduce='min',
+            op_elementwise='add',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'min', 'subtract',
+        _einspec(
+            op_reduce='min',
+            op_elementwise='subtract',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'min', 'multiply',
+        _einspec(
+            op_reduce='min',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'min', 'divide',
+        _einspec(
+            op_reduce='min',
+            op_elementwise='divide',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'max', 'add',
+        _einspec(
+            op_reduce='max',
+            op_elementwise='add',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'max', 'subtract',
+        _einspec(
+            op_reduce='max',
+            op_elementwise='subtract',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'max', 'multiply',
+        _einspec(
+            op_reduce='max',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
+    (
+        (10,), (10,), (),
+        'max', 'divide',
+        _einspec(
+            op_reduce='max',
+            op_elementwise='divide',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None),),
+            index_rhs=(slice(None),),
+            ax_contraction=(0,)),
+    ),
 ])
 def test_generic_inner(case):
     tol = 20 * ab.finfo(ab.float32).eps
 
-    lhs_shape, rhs_shape, spec, reduction, pairwise = case
+    lhs_shape, rhs_shape, result_shape, reduction, pairwise, ffspec = case
     lhs = ab.normal(0.0, 1.0, lhs_shape)
     rhs = ab.normal(0.0, 1.0, rhs_shape)
     truth = getattr(ab, reduction)(getattr(ab, pairwise)(lhs, rhs))
-    res = _einop(spec, lhs, rhs, reduction, pairwise)
+    res = _einop(lhs, rhs, ffspec, result_shape)
     assert truth.shape == res.shape
     assert ab.allclose(truth, res, tol)
 
 
 @pytest.mark.parametrize('case', [
-    ((3,), (3,), 'i,i->i|i'),
-    ((1,), (5,), 'i,i->i|i'),
-    ((2, 2), (2, 2), 'ij,ij->ij|ij'),
-    ((2, 2), (2, 3), 'ij,ij->ij|ij'),
-    ((2, 2), (3, 3), 'ij,ij->ij|ij'),
-    ((2, 2), (3, 4), 'ij,ij->ij|ij'),
-    ((2, 2), (2, 2), 'ij,ij->ij|ij'),
-    ((2, 3), (2, 2), 'ij,ij->ij|ij'),
-    ((3, 3), (2, 2), 'ij,ij->ij|ij'),
-    ((3, 4), (2, 2), 'ij,ij->ij|ij'),
-    ((2, 3, 4), (4, 1, 5), 'ijk,ijk->ijk|ijk'),
+    (
+        (3,), (3,), (9,),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None), None),
+            index_rhs=(None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (1,), (5,), (5,),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0,),
+            tran_rhs=(0,),
+            index_lhs=(slice(None), None),
+            index_rhs=(None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 2), (2, 2), (4, 4),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 2), (2, 3), (4, 6),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 2), (3, 3), (6, 6),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 2), (3, 4), (6, 8),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 2), (2, 2), (4, 4),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 3), (2, 2), (4, 6),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (3, 3), (2, 2), (6, 6),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (3, 4), (2, 2), (6, 8),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1),
+            tran_rhs=(0, 1),
+            index_lhs=(slice(None), None, slice(None), None),
+            index_rhs=(None, slice(None), None, slice(None)),
+            ax_contraction=()),
+    ),
+    (
+        (2, 3, 4), (4, 1, 5), (8, 3, 20),
+        _einspec(
+            op_reduce='sum',
+            op_elementwise='multiply',
+            tran_lhs=(0, 1, 2),
+            tran_rhs=(0, 1, 2),
+            index_lhs=(
+                slice(None), None, slice(None), None, slice(None), None
+            ),
+            index_rhs=(
+                None, slice(None), None, slice(None), None, slice(None)
+            ),
+            ax_contraction=()),
+    ),
 ])
 def test_kron(case):
     tol = 100 * ab.finfo(ab.float32).eps
 
-    lhs_shape, rhs_shape, spec = case
+    lhs_shape, rhs_shape, result_shape, ffspec = case
     lhs = ab.normal(0.0, 1.0, lhs_shape)
     rhs = ab.normal(0.0, 1.0, rhs_shape)
     truth = ab.kron(lhs, rhs)
-    res = _einop(spec, lhs, rhs, 'sum', 'multiply')
+    res = _einop(lhs, rhs, ffspec, result_shape)
     assert truth.shape == res.shape
     assert ab.allclose(truth, res, tol)

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -4,7 +4,7 @@ from numbers import Integral
 from funfact.lang.interpreter import (
     dfs_filter,
     TypeDeducer,
-    EinsteinSpecGenerator,
+    EinopCompiler,
     Evaluator,
     IndexnessAnalyzer,
     LeafInitializer,
@@ -40,7 +40,7 @@ class Factorization:
         self._tsrex = (tsrex
                        | IndexnessAnalyzer()
                        | TypeDeducer()
-                       | EinsteinSpecGenerator())
+                       | EinopCompiler())
         self.__dict__.update(**extra_attributes)
 
     @classmethod

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -3,7 +3,7 @@
 from numbers import Integral
 from funfact.lang.interpreter import (
     dfs_filter,
-    Compiler,
+    TypeDeducer,
     EinsteinSpecGenerator,
     Evaluator,
     IndexnessAnalyzer,
@@ -39,7 +39,7 @@ class Factorization:
     def __init__(self, tsrex, **extra_attributes):
         self._tsrex = (tsrex
                        | IndexnessAnalyzer()
-                       | Compiler()
+                       | TypeDeducer()
                        | EinsteinSpecGenerator())
         self.__dict__.update(**extra_attributes)
 

--- a/funfact/vectorization.py
+++ b/funfact/vectorization.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from funfact.lang import index
-from funfact.lang.interpreter import IndexnessAnalyzer, Compiler, Vectorizer
+from funfact.lang.interpreter import (
+    IndexnessAnalyzer,
+    TypeDeducer,
+    Vectorizer
+)
 from funfact.model import Factorization
 
 
@@ -33,7 +37,12 @@ def vectorize(tsrex, n, append: bool = False):
             A vectorized tensor expression.
     '''
     i = index().root
-    return tsrex | IndexnessAnalyzer() | Compiler() | Vectorizer(n, i, append)
+    return (
+        tsrex |
+        IndexnessAnalyzer() |
+        TypeDeducer() |
+        Vectorizer(n, i, append)
+    )
 
 
 def view(fac, tsrex_scalar, instance: int, append: bool = False):


### PR DESCRIPTION
Implements the mechanism as suggested in #182.