### PR TITLE
First integration tests

### DIFF
--- a/tests/test_tsrex.py
+++ b/tests/test_tsrex.py
@@ -8,22 +8,18 @@ from funfact import active_backend as ab
 
 @pytest.fixture
 def my_arrays():
-    a = np.reshape(np.arange(0, 6), (2, 3))
-    b = np.reshape(np.arange(6, 14), (2, 4))
-    return a, b
+    a = ab.tensor(np.reshape(np.arange(0, 6), (2, 3)), dtype=ab.float32)
+    b = ab.tensor(np.reshape(np.arange(6, 14), (2, 4)), dtype=ab.float32)
+    c = ab.tensor(np.reshape(np.arange(15, 75), (3, 4, 5)), dtype=ab.float32)
+    return a, b, c
 
 
 @pytest.fixture
-def my_tensors(my_arrays):
-    a_arr, b_arr = my_arrays
+def my_tsrexs(my_arrays):
+    a_arr, b_arr, c_arr = my_arrays
     a = ff.tensor('a', 2, 3, initializer=a_arr)
     b = ff.tensor('b', 2, 4, initializer=b_arr)
-    return a, b
-
-
-@pytest.fixture
-def my_tsrexs(my_tensors):
-    a, b = my_tensors
+    c = ff.tensor('c', 3, 4, 5, initializer=c_arr)
     i, j, k, p, q = ff.indices('i, j, k, p, q')
     return [
         a[k, i] * b[k, j],
@@ -31,24 +27,26 @@ def my_tsrexs(my_tensors):
         a[~k, ~i] * a[k, i],
         a[k, i] * a[k, i],
         a[k, i] * b[k, j] >> [j, i],
-        a[k, i] * b[k, j] >> [p, q]
+        a[k, i] * b[k, j] >> [p, q],
+        a[k, i] * c[i, j, p]
     ]
 
 
 @pytest.fixture
 def my_expected(my_arrays):
-    a, b = my_arrays
+    a, b, c = my_arrays
     return [
-        ((3, 4), ab.tensor(np.transpose(a) @ b, dtype=ab.float32)),
-        ((2, 3), ab.tensor(a * a, dtype=ab.float32)),
-        ((2, 3), ab.tensor(a * a, dtype=ab.float32)),
-        ((),     ab.tensor(np.sum(a * a), dtype=ab.float32)),
-        ((4, 3), ab.tensor(np.transpose(b) @ a, dtype=ab.float32)),
-        SyntaxError
+        ((3, 4), ab.transpose(a, (1, 0)) @ b),
+        ((2, 3), a * a),
+        ((2, 3), a * a),
+        ((),     ab.sum(a * a)),
+        ((4, 3), ab.transpose(b, (1, 0)) @ a),
+        SyntaxError,
+        ((2, 4, 5), ab.einsum('ki, ijp->kjp', a, c))
     ]
 
 
-def test_fixture(my_tsrexs, my_expected):
+def test_tsrex_shape_result(my_tsrexs, my_expected):
     for tsrex, expected in zip(my_tsrexs, my_expected):
         if isinstance(expected, type) and issubclass(expected, Exception):
             with pytest.raises(expected):

--- a/tests/test_tsrex.py
+++ b/tests/test_tsrex.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+import funfact as ff
+import numpy as np
+from funfact import active_backend as ab
+
+
+@pytest.fixture
+def my_arrays():
+    a = np.reshape(np.arange(0, 6), (2, 3))
+    b = np.reshape(np.arange(6, 14), (2, 4))
+    return a, b
+
+
+@pytest.fixture
+def my_tensors(my_arrays):
+    a_arr, b_arr = my_arrays
+    a = ff.tensor('a', 2, 3, initializer=a_arr)
+    b = ff.tensor('b', 2, 4, initializer=b_arr)
+    return a, b
+
+
+@pytest.fixture
+def my_tsrexs(my_tensors):
+    a, b = my_tensors
+    i, j, k, p, q = ff.indices('i, j, k, p, q')
+    return [
+        a[k, i] * b[k, j],
+        a * a,
+        a[~k, ~i] * a[k, i],
+        a[k, i] * a[k, i],
+        a[k, i] * b[k, j] >> [j, i],
+        a[k, i] * b[k, j] >> [p, q]
+    ]
+
+
+@pytest.fixture
+def my_expected(my_arrays):
+    a, b = my_arrays
+    return [
+        ((3, 4), ab.tensor(np.transpose(a) @ b, dtype=ab.float32)),
+        ((2, 3), ab.tensor(a * a, dtype=ab.float32)),
+        ((2, 3), ab.tensor(a * a, dtype=ab.float32)),
+        ((),     ab.tensor(np.sum(a * a), dtype=ab.float32)),
+        ((4, 3), ab.tensor(np.transpose(b) @ a, dtype=ab.float32)),
+        SyntaxError
+    ]
+
+
+def test_fixture(my_tsrexs, my_expected):
+    for tsrex, expected in zip(my_tsrexs, my_expected):
+        if isinstance(expected, type) and issubclass(expected, Exception):
+            with pytest.raises(expected):
+                tsrex.shape
+        else:
+            shape, result = expected
+            assert tsrex.shape == shape
+            fac = ff.Factorization.from_tsrex(tsrex)
+            assert ab.allclose(fac(), result)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
-changedir = funfact
+#changedir = funfact
+changedir = tests
 whitelist_externals = bash
 extras =
     devel


### PR DESCRIPTION
Some first integration tests that cover a few of the recently fixed bugs.

@yhtang `tox.ini` is changed to the `tests` directory. This runs the tests in that folder, but no longer the unit tests in the `funfact` directory. Can you have a look at this? Maybe a reasonable solution would be to create a `unit` and `integration` subdirectory in `tests` and move all tests there?