### PR TITLE
Parametrized Tensors

### DIFF
--- a/funfact/__init__.py
+++ b/funfact/__init__.py
@@ -13,7 +13,7 @@ from .context import is_grad_on, enable_grad
 from . import initializers
 from . import conditions
 from .lang._semiring import minplus, logsumexp, viterbi
-
+from . import generators
 
 __all__ = [
     'use',
@@ -37,7 +37,8 @@ __all__ = [
     'conditions',
     'minplus',
     'logsumexp',
-    'viterbi'
+    'viterbi',
+    'generators'
 ]
 
 

--- a/funfact/__init__.py
+++ b/funfact/__init__.py
@@ -13,7 +13,7 @@ from .context import is_grad_on, enable_grad
 from . import initializers
 from . import conditions
 from .lang._semiring import minplus, logsumexp, viterbi
-from . import generators
+from . import parametrized
 
 __all__ = [
     'use',
@@ -38,7 +38,7 @@ __all__ = [
     'minplus',
     'logsumexp',
     'viterbi',
-    'generators'
+    'parametrized'
 ]
 
 

--- a/funfact/generators.py
+++ b/funfact/generators.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from typing import Callable
+from funfact import active_backend as ab
+from funfact.lang._tsrex import TsrEx
+from funfact.lang._ast import Primitives as P
+from funfact.lang._terminal import ParametrizedAbstractTensor
+
+class Generator:
+    ''' A generator can generate a tensor from a set of parameters.
+
+    Args:
+        shape_param: Tuple(Int):
+            Shape of the parameters to generate tensor.
+        generator: Callable:
+            Function to generate tensor from parameters.
+    '''
+    def __init__(self, shape_param, generator: Callable):
+        self._shape_param = shape_param
+        self._generator = generator
+
+    def __call__(self, param):
+        return self._generator(param)
+
+    @property
+    def shape_param(self):
+        return self._shape_param
+
+    def vectorize(self, n, append: bool = True):
+        '''Vectorize to n replicas.'''
+
+        def wrapper(params):
+            '''Vectorized generator.'''
+            def _get_instance(i):
+                return params[..., i] if append else params[i, ...]
+            axis = -1 if append else 0
+            return ab.stack(
+                [self._gen(_get_instance(i)) for i in range(n)], axis
+            )
+
+        self._generator = wrapper
+        self._shape_param = (*self._shape_param, n) if append else \
+                            (n, *self._shape_param)
+
+
+def _gen_rotation(theta):
+    return ab.tensor([[ab.cos(theta), -ab.sin(theta)],
+                      [ab.sin(theta), ab.cos(theta)]])
+
+
+# TODO: make it nxn on i,j?
+def givens_rotation():
+    return TsrEx(
+        P.parametrized_tensor(
+            ParametrizedAbstractTensor(
+                2, 2, symbol='G', initializer=None, optimizable=True,
+                generator=Generator(1, _gen_rotation)
+            )
+        )
+    )
+        

--- a/funfact/lang/_ast.py
+++ b/funfact/lang/_ast.py
@@ -4,7 +4,9 @@ from dataclasses import make_dataclass
 import inspect
 from numbers import Real
 from typing import Optional, Union, Tuple
-from ._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from ._terminal import (
+    AbstractIndex, AbstractTensor, LiteralValue, ParametrizedAbstractTensor
+)
 
 
 class _ASNode:
@@ -52,6 +54,10 @@ class Primitives:
     @primitive(precedence=0)
     def literal(value: LiteralValue):
         '''a literal value'''
+
+    @primitive(precedence=0)
+    def parametrized_tensor(decl: ParametrizedAbstractTensor):
+        '''a parametrized tensor'''
 
     @primitive(precedence=0)
     def tensor(decl: AbstractTensor):

--- a/funfact/lang/_terminal.py
+++ b/funfact/lang/_terminal.py
@@ -140,7 +140,7 @@ class AbstractTensor(Identifiable, LaTexReprMixin):
     '''An abstract tensor is a symbolic representation of a multidimensional
     array and is convenient for specifying **tensor expressions**. At
     construction, it does not allocate memory nor populate elements, but rather
-    just record the shape, the method of initializerization, and other related
+    just record the shape, the method of initialization, and other related
     properties for a tensor. This is in contrast to the behavior of common
     linear algebra libraries, where multidimensional arrays are 'eager' in
     allocating memory and creating the data.
@@ -227,3 +227,47 @@ class AbstractTensor(Identifiable, LaTexReprMixin):
             return fr'\boldsymbol{{{letter}}}^{{({number})}}'
         else:
             return fr'\boldsymbol{{{letter}}}'
+
+
+class ParametrizedAbstractTensor(AbstractTensor):
+    '''A parametrized abstract tensor is a symbolic representation of a
+    multidimensional array that depends on some parameters. The tensor
+    representation can be generated from the parameters.
+
+    Parameters
+    ----------
+    shape: int...:
+        A sequence of integers specifying the shape of the tensor.
+        Can be either a variable number of arguments or an iterable like a list
+        or tuple.
+
+    symbol (str):
+        An alphanumeric symbol representing the abstract tensor
+
+    initializer (callable):
+        Initialization distribution for parameters or concrete values for
+        parameters.
+
+    optimizable (boolean):
+        True/False flag indicating of the abstract tensor can be optimized.
+
+    generator (callable):
+        Generates tensor representation from parameters. A generator has a few
+        properties: `size` of the tensor, `nparams` required to generate the
+        tensor.
+    '''
+    def __init__(self, *shape, symbol=None, initializer=None, optimizable=True,
+                 generator=None):
+        super().__init__(*shape, symbol=symbol, initializer=initializer,
+                         optimizable=optimizable, prefer=None)
+        self.generator = generator
+
+    def vectorize(self, n, append):
+        '''Extend dimensionality by one.'''
+        vectorized = super().vectorize(n, append)
+        if self.generator is None:
+            generator = self.generator
+        else:
+            generator = self.generator.vectorize(n, append)
+        vectorized.generator = generator
+        return vectorized

--- a/funfact/lang/_terminal.py
+++ b/funfact/lang/_terminal.py
@@ -257,17 +257,17 @@ class ParametrizedAbstractTensor(AbstractTensor):
         tensor.
     '''
     def __init__(self, *shape, symbol=None, initializer=None, optimizable=True,
-                 generator=None):
+                 generator=None, **kwargs):
         super().__init__(*shape, symbol=symbol, initializer=initializer,
                          optimizable=optimizable, prefer=None)
         self.generator = generator
 
     def vectorize(self, n, append):
         '''Extend dimensionality by one.'''
-        vectorized = super().vectorize(n, append)
         if self.generator is None:
             generator = self.generator
         else:
             generator = self.generator.vectorize(n, append)
+        vectorized = super().vectorize(n, append)
         vectorized.generator = generator
         return vectorized

--- a/funfact/lang/interpreter/_ascii.py
+++ b/funfact/lang/interpreter/_ascii.py
@@ -23,6 +23,10 @@ class ASCIIRenderer(TranscribeInterpreter):
         return str(value)
 
     @as_payload
+    def parametrized_tensor(self, decl, **kwargs):
+        return str(decl.symbol)
+
+    @as_payload
     def tensor(self, decl, **kwargs):
         return str(decl.symbol)
 

--- a/funfact/lang/interpreter/_base.py
+++ b/funfact/lang/interpreter/_base.py
@@ -5,7 +5,9 @@ import copy
 from enum import Enum
 from typing import Any, Callable, Iterable, Optional, Tuple
 from funfact.lang._ast import _ASNode, _AST, Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex, AbstractTensor, LiteralValue, ParametrizedAbstractTensor
+)
 from funfact.util.iterable import flatten_if
 
 
@@ -86,6 +88,10 @@ class ROOFInterpreter(ABC):
 
     @abstractmethod
     def literal(self, value: LiteralValue, **payload):
+        pass
+
+    @abstractmethod
+    def parametrized_tensor(self, decl: ParametrizedAbstractTensor, **payload):
         pass
 
     @abstractmethod
@@ -175,6 +181,10 @@ class TranscribeInterpreter(ABC):
 
     @abstractmethod
     def literal(self, value: LiteralValue, **payload):
+        pass
+
+    @abstractmethod
+    def parametrized_tensor(self, decl: ParametrizedAbstractTensor, **payload):
         pass
 
     @abstractmethod

--- a/funfact/lang/interpreter/_einop_compiler.py
+++ b/funfact/lang/interpreter/_einop_compiler.py
@@ -3,7 +3,9 @@
 from typing import Optional, Tuple
 import numpy as np
 from funfact.lang._ast import Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex, AbstractTensor, LiteralValue, ParametrizedAbstractTensor
+)
 from funfact.util.iterable import as_namedtuple
 from ._base import _as_payload, TranscribeInterpreter
 
@@ -26,6 +28,9 @@ class EinopCompiler(TranscribeInterpreter):
         raise NotImplementedError()
 
     def literal(self, value: LiteralValue, **kwargs):
+        return []
+
+    def parametrized_tensor(self, decl: ParametrizedAbstractTensor, **kwargs):
         return []
 
     def tensor(self, decl: AbstractTensor, **kwargs):

--- a/funfact/lang/interpreter/_elementwise.py
+++ b/funfact/lang/interpreter/_elementwise.py
@@ -15,7 +15,10 @@ def _sliced_size(sli, sz):
 
 class ElementwiseEvaluator(Evaluator):
     def parametrized_tensor(self, decl, data, slices, **kwargs):
-        return decl.generator(data)[slices]
+        try:
+            return decl.generator(data, slices)
+        except TypeError:
+            return decl.generator(data)[slices]
 
     def tensor(self, decl, data, slices, **kwargs):
         return data[slices]

--- a/funfact/lang/interpreter/_elementwise.py
+++ b/funfact/lang/interpreter/_elementwise.py
@@ -14,6 +14,9 @@ def _sliced_size(sli, sz):
 
 
 class ElementwiseEvaluator(Evaluator):
+    def parametrized_tensor(self, decl, data, slices, **kwargs):
+        return decl.generator(data)[slices]
+
     def tensor(self, decl, data, slices, **kwargs):
         return data[slices]
 

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -18,6 +18,9 @@ class Evaluator(ROOFInterpreter):
     def literal(self, value, **kwargs):
         return ab.tensor(value.raw)
 
+    def parametrized_tensor(self, decl, data,  **kwargs):
+        return decl.generator(data)
+
     def tensor(self, decl, data, **kwargs):
         return data
 

--- a/funfact/lang/interpreter/_evaluation.py
+++ b/funfact/lang/interpreter/_evaluation.py
@@ -18,7 +18,7 @@ class Evaluator(ROOFInterpreter):
     def literal(self, value, **kwargs):
         return ab.tensor(value.raw)
 
-    def parametrized_tensor(self, decl, data,  **kwargs):
+    def parametrized_tensor(self, decl, data, **kwargs):
         return decl.generator(data)
 
     def tensor(self, decl, data, **kwargs):

--- a/funfact/lang/interpreter/_indexness.py
+++ b/funfact/lang/interpreter/_indexness.py
@@ -6,7 +6,9 @@ from ._base import (
     TranscribeInterpreter
 )
 from funfact.lang._ast import Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex, AbstractTensor, LiteralValue, ParametrizedAbstractTensor
+)
 
 
 class IndexnessAnalyzer(TranscribeInterpreter):
@@ -36,6 +38,10 @@ class IndexnessAnalyzer(TranscribeInterpreter):
 
     @as_payload
     def literal(self, value: LiteralValue, **kwargs):
+        return False
+
+    @as_payload
+    def parametrized_tensor(self, decl: ParametrizedAbstractTensor, **kwargs):
         return False
 
     @as_payload

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -25,6 +25,34 @@ class LeafInitializer(TranscribeInterpreter):
         return []
 
     @_as_payload('data')
+    def parametrized_tensor(self, decl, **kwargs):
+        initializer, optimizable, shape_param = (
+            decl.initializer, decl.optimizable, decl.generator.shape_param
+        )
+        if initializer is None:
+            initializer = Normal(dtype=self.dtype)
+        elif isinstance(initializer, type):
+            '''got an initializer class'''
+            initializer = initializer(dtype=self.dtype)
+        try:
+            return ab.set_optimizable(initializer(shape_param), optimizable)
+        except TypeError:
+            # If optimizable, slice for each instance must be independent.
+            # Otherwise, slices can share a view into the original tensor.
+            ini = ab.tensor(initializer, dtype=self.dtype)
+            if np.any(np.remainder(shape_param, ini.shape) != 0):
+                raise ValueError(
+                    f'Concrete initializer of shape {ini.shape} cannot be '
+                    f'broadcasted to initialize parameters of tensor of '
+                    f'shape {shape_param}.'
+                )
+            if optimizable:
+                ini = ab.tile(ini, [s // d for s, d in zip(shape_param, ini.shape)])
+            else:
+                ini = ab.broadcast_to(ini, shape_param)
+            return ab.set_optimizable(ini, optimizable=optimizable)
+
+    @_as_payload('data')
     def tensor(self, decl, **kwargs):
         initializer, optimizable, shape = (
             decl.initializer, decl.optimizable, decl.shape

--- a/funfact/lang/interpreter/_initialization.py
+++ b/funfact/lang/interpreter/_initialization.py
@@ -47,7 +47,8 @@ class LeafInitializer(TranscribeInterpreter):
                     f'shape {shape_param}.'
                 )
             if optimizable:
-                ini = ab.tile(ini, [s // d for s, d in zip(shape_param, ini.shape)])
+                ini = ab.tile(ini, [s // d for s, d in
+                              zip(shape_param, ini.shape)])
             else:
                 ini = ab.broadcast_to(ini, shape_param)
             return ab.set_optimizable(ini, optimizable=optimizable)

--- a/funfact/lang/interpreter/_latex.py
+++ b/funfact/lang/interpreter/_latex.py
@@ -42,6 +42,9 @@ class LatexRenderer(ROOFInterpreter):
     def literal(self, value, **kwargs):
         return value._repr_tex_()
 
+    def parametrized_tensor(self, decl, **kwargs):
+        return decl._repr_tex_()
+
     def tensor(self, decl, **kwargs):
         return decl._repr_tex_()
 

--- a/funfact/lang/interpreter/_slicing_propagation.py
+++ b/funfact/lang/interpreter/_slicing_propagation.py
@@ -35,6 +35,9 @@ class SlicingPropagator(TranscribeInterpreter):
     def literal(self, value: LiteralValue, **kwargs):
         pass
 
+    def parametrized_tensor(self, decl, **kwargs):
+        pass
+
     def tensor(self, decl: AbstractTensor, **kwargs):
         pass
 

--- a/funfact/lang/interpreter/_type_deduction.py
+++ b/funfact/lang/interpreter/_type_deduction.py
@@ -9,7 +9,9 @@ from ._base import (
     RewritingTranscriber,
 )
 from funfact.lang._ast import Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex, AbstractTensor, LiteralValue, ParametrizedAbstractTensor
+)
 from funfact.util.iterable import as_namedtuple
 from funfact.util.set import ordered_intersect, ordered_union, ordered_setminus
 
@@ -131,12 +133,16 @@ class TypeDeducer(RewritingTranscriber):
         return None, None, None, ()
 
     @as_payload
+    def parametrized_tensor(self, decl: ParametrizedAbstractTensor, **kwargs):
+        return None, None, None, decl.shape
+
+    @as_payload
     def tensor(self, decl: AbstractTensor, **kwargs):
         return None, None, None, decl.shape
 
     @as_payload
     def ellipsis(self, **payload):
-        return None, None, None, None
+        return [P.ellipsis()], [], [], None
 
     @as_payload
     def index(self, item: AbstractIndex, bound: bool, kron: bool, **kwargs):

--- a/funfact/lang/interpreter/_vectorize.py
+++ b/funfact/lang/interpreter/_vectorize.py
@@ -3,7 +3,9 @@
 import dataclasses
 from typing import Optional
 from funfact.lang._ast import Primitives as P
-from funfact.lang._terminal import AbstractIndex, AbstractTensor, LiteralValue
+from funfact.lang._terminal import (
+    AbstractIndex, AbstractTensor, LiteralValue, ParametrizedAbstractTensor
+)
 from ._base import _as_payload, TranscribeInterpreter
 
 
@@ -42,6 +44,10 @@ class Vectorizer(TranscribeInterpreter):
 
     def index(self, item: AbstractIndex, bound: bool, **kwargs):
         return []
+
+    @_as_payload('decl')
+    def parametrized_tensor(self, decl: ParametrizedAbstractTensor, **kwargs):
+        return decl.vectorize(self.replicas, self.append)
 
     @_as_payload('decl')
     def tensor(self, decl: AbstractTensor, **kwargs):

--- a/funfact/model/_factorization.py
+++ b/funfact/model/_factorization.py
@@ -105,7 +105,8 @@ class Factorization:
         return self._NodeView(
             'data',
             list(unique(dfs_filter(
-                lambda n: n.name == 'tensor' and n.decl.optimizable,
+                lambda n: n.name in ['tensor', 'parametrized_tensor'] and
+                n.decl.optimizable,
                 self.tsrex.root
             )))
         )
@@ -113,8 +114,8 @@ class Factorization:
     @factors.setter
     def factors(self, tensors):
         for i, n in enumerate(unique(
-            dfs_filter(lambda n: n.name == 'tensor' and
-                       n.decl.optimizable, self.tsrex.root)
+            dfs_filter(lambda n: n.name in ['tensor', 'parametrized_tensor']
+                       and n.decl.optimizable, self.tsrex.root)
         )):
             n.data = tensors[i]
 

--- a/funfact/parametrized.py
+++ b/funfact/parametrized.py
@@ -68,6 +68,22 @@ def planar_rotation(i, j, n):
             size of rotation matrix.
     '''
 
+    if not (isinstance(n, numbers.Integral) and n > 0):
+        raise RuntimeError(
+                "Shape of the planar rotation must be a positive integer, "
+                f"got {n}."
+                )
+
+    def _check_rc(idx):
+        if not (isinstance(idx, numbers.Integral) and idx < n and idx >= 0):
+            raise RuntimeError(
+                f"Row/column index must be between [0, {n}], "
+                f"got {idx}."
+            )
+
+    _check_rc(i)
+    _check_rc(j)
+
     min_idx = min(i, j)
     max_idx = max(i, j)
 
@@ -88,10 +104,11 @@ def planar_rotation(i, j, n):
         p = np.argsort(p)
         return rot[p, :][:, p]
 
+    symbol_str = 'G_' + str(min_idx) + str(max_idx) + str(n)
     return TsrEx(
         P.parametrized_tensor(
             ParametrizedAbstractTensor(
-                Generator(_gen_rotation, 1), n, n, symbol='G',
+                Generator(_gen_rotation, 1), n, n, symbol=symbol_str,
                 initializer=None, optimizable=True
             )
         )

--- a/funfact/parametrized.py
+++ b/funfact/parametrized.py
@@ -32,7 +32,7 @@ class Generator:
             self.generator = generator
             self.n = n
             self.append = append
-        
+
         def __call__(self, params):
             def _get_instance(i):
                 return params[..., i] if self.append else params[i, ...]
@@ -49,19 +49,43 @@ class Generator:
         return type(self)(shape_param, generator)
 
 
-def _gen_rotation(theta):
-    return ab.tensor([[ab.cos(theta), -ab.sin(theta)],
-                      [ab.sin(theta), ab.cos(theta)]])
+def givens_rotation(i, j, n):
+    '''Generate an nxn parametrized Givens rotation with the rotation acting
+    on the [(i,j), (i,j)] submatrix.
 
+    Args
+        i: int:
+            first row/column index for Givens rotation
+        j: int:
+            second row/column index for Givens rotation
+        n: int:
+            size of rotation matrix.
+    '''
+    def _gen_rotation(theta):
+        rot = ab.eye(n, n)
+        # rot = rot.at[i, i].set(ab.cos(theta[0]))
+        # rot = rot.at[i, j].set(-ab.sin(theta[0]))
+        # rot = rot.at[j, j].set(ab.cos(theta[0]))
+        # rot = rot.at[j, i].set(ab.sin(theta[0]))
+        rot[i, i] = ab.cos(theta)
+        rot[i, j] = -ab.sin(theta)
+        rot[j, i] = ab.sin(theta)
+        rot[j, j] = ab.cos(theta)
+        return rot
 
-# TODO: make it nxn on i,j?
-def givens_rotation():
+    '''
+    def _gen_rotation(theta):
+        return ab.vstack(
+            [ab.hstack([ab.cos(theta), -ab.sin(theta)]),
+             ab.hstack([ab.sin(theta), ab.cos(theta)])]
+    )
+    '''
+
     return TsrEx(
         P.parametrized_tensor(
             ParametrizedAbstractTensor(
-                2, 2, symbol='G', initializer=None, optimizable=True,
+                n, n, symbol='G', initializer=None, optimizable=True,
                 generator=Generator((1,), _gen_rotation)
             )
         )
     )
-        

--- a/funfact/parametrized.py
+++ b/funfact/parametrized.py
@@ -54,7 +54,7 @@ class Generator:
         return type(self)(generator, *shape_of_params)
 
 
-def planar_rotation(i, j, n):
+def planar_rotation(i, j, n, initializer=None, optimizable=True):
     '''Generate an n x n planar rotation parameterized by a single rotation
     angle with the rotation acting on the [(i,j), (i,j)] submatrix nof the
     n x n identity matrix.
@@ -66,6 +66,10 @@ def planar_rotation(i, j, n):
             second row/column index for Givens rotation
         n: int:
             size of rotation matrix.
+        initializer (callable):
+            Initialization distribution
+        optimizable (boolean):
+            True/False flag indicating if a tensor leaf should be optimized.
     '''
 
     if not (isinstance(n, numbers.Integral) and n > 0):
@@ -109,7 +113,7 @@ def planar_rotation(i, j, n):
         P.parametrized_tensor(
             ParametrizedAbstractTensor(
                 Generator(_gen_rotation, 1), n, n, symbol=symbol_str,
-                initializer=None, optimizable=True
+                initializer=initializer, optimizable=optimizable
             )
         )
     )


### PR DESCRIPTION
This PR adds a framework to add parametrized tensors to FunFact and closes #220 upon completion. An example implementation for parametrized Givens rotations is provided.

Example usage to compute a Givens QR factorization of a 2 x 2 matrix:
```py
G = ff.parametrized.planar_rotation(0, 1, 2)
R = ff.tensor('R', 2, 2, prefer=ff.conditions.UpperTriangular())
tsrex = G @ R
target = np.array([[1.0, 2.0], [3.0, 4.0]])
fac = ff.factorize(tsrex, target, vec_size=8)
fac()
```

There is an outstanding issue with the generation of the rotation matrices with the JAX backend that is related to the immutability property of `DeviceArray`s we encountered before. The commented out code in `funfact.parametrized.givens_rotation` uses the idea from: https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#in-place-updates
@yhtang do you see a better way to construct these parametrized tensors?

The code is compatible with PyTorch. 