### PR TITLE
Eliminate unnecessary type promotion in elementwise power

### DIFF
--- a/funfact/backend/_torch.py
+++ b/funfact/backend/_torch.py
@@ -87,6 +87,10 @@ def sum(a, axis=None):
         return torch.sum(a)
 
 
+def power(input, exponent):
+    return torch.pow(input, exponent)
+
+
 def reshape(a, newshape, order='C'):
     if order == 'C':
         return torch.reshape(a, (*newshape,))

--- a/funfact/lang/_tsrex.py
+++ b/funfact/lang/_tsrex.py
@@ -251,7 +251,7 @@ class SyntaxOverloadMixin:
 
     @_as_tsrex
     def __pow__(self, rhs):
-        return _binary(_as_node(self), _as_node(rhs), 3, 'float_power')
+        return _binary(_as_node(self), _as_node(rhs), 3, 'power')
 
     @_as_tsrex
     def __and__(self, rhs):
@@ -279,7 +279,7 @@ class SyntaxOverloadMixin:
 
     @_as_tsrex
     def __rpow__(self, lhs):
-        return _binary(_as_node(lhs), _as_node(self), 3, 'float_power')
+        return _binary(_as_node(lhs), _as_node(self), 3, 'power')
 
     @_as_tsrex
     def __rand__(self, lhs):


### PR DESCRIPTION
Turns out the `torch.float_power` has the following admonition...:
> This function always computes in **double precision**, unlike [torch.pow()](https://pytorch.org/docs/stable/generated/torch.pow.html#torch.pow), which implements more typical [type promotion](https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc). This is useful when the computation needs to be performed in a wider or more precise dtype, or the results of the computation may contain fractional values not representable in the input dtypes, like when an integer base is raised to a negative integer exponent.