### PR TITLE
matrix MSE loss agnostic to global phase

### DIFF
--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -134,11 +134,13 @@ class KLDivergence(Loss):
         return ab.multiply(target, ab.log(ab.divide(target, model)))
 
 
-class GlobalPhaseMSE(MatrixLoss):
+class PhaseInvariantMSE(MatrixLoss):
     '''MSE loss for matrices agnostic to global phase.'''
     def _loss(self, model, target):
-        return ab.abs(ab.transpose(model.conj(), axes=(1, 0)) @ target) - \
-               ab.eye(model.shape[0], target.shape[1])
+        return ab.square(ab.abs(
+            ab.transpose(model.conj(), axes=(1, 0)) @ target) -
+            ab.eye(model.shape[0], target.shape[1])
+        )
 
 
 mse = MSE()

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -82,6 +82,39 @@ class Loss(ABC):
             return _loss
 
 
+class MatrixLoss(Loss):
+    '''Base class for FunFact loss functions for matrices (2D tensors).'''
+    def __call__(
+        self, model, target, sum_vec=True, vectorized_along_last=False
+    ):
+        if target.ndim != 2:
+            raise RuntimeError(f'Target is not a matrix, has {target.ndim} '
+                               'dimensions.')
+        if model.ndim == 3:  # vectorized model
+            if vectorized_along_last:
+                loss = ab.stack(
+                    [self._loss(model[..., i], target) for i in
+                     range(model.shape[-1])]
+                )
+            else:
+                loss = ab.stack(
+                    [self._loss(model[i, ...], target) for i in
+                     range(model.shape[0])]
+                )
+            data_axis = (1, 2)
+        if model.ndim == 2:  # non-vectorized model
+            loss = self._loss(model, target)
+            data_axis = (0, 1)
+        if self.reduction == 'mean':
+            loss = loss.mean(axis=data_axis)
+        if self.reduction == 'sum':
+            loss = ab.sum(loss, axis=data_axis)
+        if sum_vec:
+            return ab.sum(loss)
+        else:
+            return loss
+
+
 class MSE(Loss):
     '''Mean-Squared Error (MSE) loss.'''
     def _loss(self, model, target):
@@ -99,6 +132,13 @@ class KLDivergence(Loss):
     '''KL Divergence loss.'''
     def _loss(self, model, target):
         return ab.multiply(target, ab.log(ab.divide(target, model)))
+
+
+class GlobalPhaseMSE(MatrixLoss):
+    '''MSE loss for matrices agnostic to global phase.'''
+    def _loss(self, model, target):
+        return ab.abs(ab.transpose(model.conj(), axes=(1, 0)) @ target) - \
+               ab.eye(model.shape[0], target.shape[1])
 
 
 mse = MSE()


### PR DESCRIPTION
Loss function that doesn't take into account the global phase of the unitary.


```py
ut, _ = np.linalg.qr(np.random.randn(4, 4) + 1j * np.random.randn(4, 4))
eps = 1e-4
um, _ = np.linalg.qr(ut + eps * (np.random.randn(4, 4) + 1j * np.random.randn(4, 4)))
ut = ab.tensor(ut)
um = ab.tensor(um)
umm = ab.stack([np.exp(1j * np.random.randn()) * um for i in range(5)], dim=2)
ff.loss.mse(um, ut)  # this is small
ff.loss.mse(umm, ut, vectorized_along_last=True, sum_vec=False) # these are big
gp_mse = ff.loss.GlobalPhaseMSE()
gp_mse(umm, ut, vectorized_along_last=True, sum_vec=False) # these are small
```