### PR TITLE
Installation instructions in README and documentation landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,34 +10,22 @@
 
 ## Installation
 
-There are two default options to install FunFact:
-
-* install released versions from [PyPI](https://pypi.org/project/funfact/):
-  ```bash 
-  pip install -U funfact
-  ```
-* install the latest version from source:
-  ```bash
-  git clone https://github.com/yhtang/FunFact.git
-  cd FunFact/
-  python setup.py install
-  ```
-
-The default installation of FunFact installs the NumPy backend, which **only supports forward calculations**. The NumPy backend doesn't support automatic differentiation and is not able to optimize tensor expressions for methods such as funfact.factorize.
-
-In order to factorize tensor data by a tensor expression, two autograd backends
-are provided:
-
-* use the JAX backend:
+* To use FunFact with the JAX backend:
   ```bash
   pip install "funfact[jax]"
   ```
-* use the PyTorch backend:
+* To use FunFact with the PyTorch backend:
   ```bash
   pip install "funfact[torch]"
   ```
 
-Running the command as above will trigger default installalation of the respective packages. We refer to the [installation page](https://funfact.readthedocs.io/en/latest/pages/installation/) for more details on installation options.
+Running the command as above will install the version of the respective packages hosted on PyPI. Please refer to the [installation page](https://funfact.readthedocs.io/en/latest/pages/installation/) for more details on installation options.
+
+FunFact can also be installed with the NumPy backend, which **only supports forward calculations**. The NumPy backend doesn't support automatic differentiation and is not able to optimize tensor expressions for methods such as `funfact.factorize`.
+
+```bash 
+pip install -U funfact  # does not install JAX or PyTorch
+```
 
 ## Quick start example: semi-nonnegative CP decomposition
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,38 @@
 
 [FunFact](https://github.com/yhtang/FunFact.git) is a Python package that aims to simplify the design of matrix and tensor factorization algorithms. It features a powerful programming interface that augments the NumPy API with Einstein notations for writing concise tensor expressions. Given an arbitrary forward calculation scheme, the package will solve the corresponding inverse problem using stochastic gradient descent, automatic differentiation, and multi-replica vectorization. Its application areas include quantum circuit synthesis, tensor decomposition, and neural network compression. It is GPU- and parallelization-ready thanks to modern numerical linear algebra backends such as JAX/TensorFlow and PyTorch.
 
+## Installation
+
+There are two default options to install FunFact:
+
+* install released versions from [PyPI](https://pypi.org/project/funfact/):
+  ```bash 
+  pip install -U funfact
+  ```
+* install the latest version from source:
+  ```bash
+  git clone https://github.com/yhtang/FunFact.git
+  cd FunFact/
+  python setup.py install
+  ```
+
+The default installation of FunFact installs the NumPy backend, which **only supports forward calculations**. The NumPy backend doesn't support automatic differentiation and is not able to optimize tensor expressions for methods such as funfact.factorize.
+
+In order to factorize tensor data by a tensor expression, two autograd backends
+are provided:
+
+* use the JAX backend:
+  ```bash
+  pip install "funfact[jax]"
+  ```
+* use the PyTorch backend:
+  ```bash
+  pip install "funfact[torch]"
+  ```
+
+Running the command as above will trigger default installalation of the respective packages. We refer to the [installation page](https://funfact.readthedocs.io/en/latest/pages/installation/) for more details on installation options.
+
 ## Quick start example: semi-nonnegative CP decomposition
-
-Install from pip:
-
-``` bash 
-pip install -U funfact
-```
 
 Package import:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ tsrex = (a[i, ~r] * b[j, r]) * c[k, r]; tsrex
 Find rank-2 approximation:
 
 ``` py
->>> fac = ff.factorize(tsrex, T, max_steps=1000, nvec=8, penalty_weight=10)
+>>> fac = ff.factorize(tsrex, T, max_steps=1000, vec_size=8, penalty_weight=10)
 >>> fac.factors
 100%|██████████| 1000/1000 [00:03<00:00, 304.00it/s]
 <'data' fields of tensors a, b, c>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,10 @@
 !!! example "Install from pip"
 
     ``` bash 
-    pip install -U funfact
+    pip install -U  "funfact[torch]"
     ```
+    **Note:** this installs FunFact with the PyTorch autograd backend. See the [installation page](../pages/installation/) for more installation options.
+
 
 !!! example "Package import"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@
     === "in"
     
         ``` py
-        fac = ff.factorize(tsrex, T, max_steps=1000, nvec=8, penalty_weight=10)
+        fac = ff.factorize(tsrex, T, max_steps=1000, vec_size=8, penalty_weight=10)
         fac.factors
         ```
     

--- a/docs/pages/user-guide/factorize.md
+++ b/docs/pages/user-guide/factorize.md
@@ -28,11 +28,11 @@ factorization model as starting point for the optimization process. For more
 complicated tensor factorizations, the chances of success can be drastically
 improved by optimizing multiple random initializations simultaneously.
 This process is called *vectorization* in FunFact and the `factorize` algorithm
-can be used on a vectorized model  by specifying the `nvec` keyword integer
+can be used on a vectorized model  by specifying the `vec_size` keyword integer
 argument.
 
 ```py
-fac = ff.factorize(tsrex, target, nvec=64)
+fac = ff.factorize(tsrex, target, vec_size=64)
 ```
 
 The code above will run 64 randomly initialized models in parallel until
@@ -47,14 +47,14 @@ arguments for the `factorize` algorithm:
 stops:
     * `first`: the iteration stops as soon as one instance satisfies the
     convergence criterion.
-    * int $n \in [1, \mathrm{nvec}]$: the iteration stops as soon as `n` instances
+    * int $n \in [1, \mathrm{vec_size}]$: the iteration stops as soon as `n` instances
     satisfy the convergence criterion.
     * `None`: always run the iteration until `max_steps`.
 The default is `first`.
 
 - `returns=...` specifies what output is returned:
     * `best`: only the best instance is returned as a factorization model
-    * `all` or int $n \in [1, \mathrm{nvec}]$: returns a list of all of or the best `n` instances
+    * `all` or int $n \in [1, \mathrm{vec_size}]$: returns a list of all of or the best `n` instances
     as a list of factorization models sorted in ascending order by loss.
 The default is `best`.
 
@@ -67,7 +67,7 @@ An example use case is:
 
 ```py
 fac = ff.factorize(tsrex, target, 
-                   nvec=64, 
+                   vec_size=64, 
                    append=False, 
                    stop_by=None, 
                    returns=8

--- a/funfact/loss.py
+++ b/funfact/loss.py
@@ -143,6 +143,17 @@ class PhaseInvariantMSE(MatrixLoss):
         )
 
 
+class PhaseInvariantL1(MatrixLoss):
+    '''L1 loss for matrices agnostic to global phase.'''
+    def _loss(self, model, target):
+        return ab.abs(ab.abs(
+            ab.transpose(model.conj(), axes=(1, 0)) @ target) -
+            ab.eye(model.shape[0], target.shape[1])
+        )
+
+
 mse = MSE()
 l1 = L1()
 kl_divergence = KLDivergence()
+phase_invariant_mse = PhaseInvariantMSE()
+phase_invariant_l1 = PhaseInvariantL1()


### PR DESCRIPTION
As indicated by @fabian-sp in #241, following the installation instructions on the GitHub README page and landing page on readthedocs only installs the NumPy backend which does not enable autograd functionalities.

This PR adds more descriptive installation instructions to the README and provides links to the installation page in both the README and readthedocs landing page. 